### PR TITLE
Have tests use tasty.

### DIFF
--- a/consensus-paxos/tests/Test.hs
+++ b/consensus-paxos/tests/Test.hs
@@ -49,11 +49,11 @@ setup transport action = do
 proposeWrapper :: [ProcessId] -> DecreeId -> Int -> Process Bool
 proposeWrapper αs d x = (x ==) <$> runPropose (BasicPaxos.propose αs d x)
 
-tests :: IO [Test]
+tests :: IO TestTree
 tests = do
     Right transport <- createTransport "127.0.0.1" "8080" defaultTCPParameters
 
-    return
+    return $ testGroup "consensus-paxos"
       [ testSuccess "single-decree" $ setup transport $ \them -> do
             assert =<< proposeWrapper them (DecreeId 0 0) 42
       , testSuccess "two-decree"    $ setup transport $ \them -> do

--- a/distributed-process-test/distributed-process-test.cabal
+++ b/distributed-process-test/distributed-process-test.cabal
@@ -22,15 +22,28 @@ Library
   Exposed-Modules:  Test.Framework
                     Test.Driver
   Build-Depends:    base >= 4.5,
-                    Cabal >= 1.16,
                     containers,
                     data-accessor,
                     directory >= 1.2,
                     distributed-process >= 0.4,
                     network-transport,
+                    -- see note [Tasty upper bound]
+                    tasty >= 0.7 && < 0.8,
+                    tasty-hunit,
                     unix,
                     regex-posix
   Ghc-Options:      -Wall -Werror
   Default-Extensions: DeriveDataTypeable
                       RecordWildCards
                       ScopedTypeVariables
+
+-- Note [Tasty upper bound]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~
+--
+-- Tasty 0.8 fails to build with compilation errors related to missing
+-- functions in the ansi-terminal interface. Later versions of tasty
+-- cannot be used as they depend on a version of ansi-terminal that
+-- d-p-p bans with an upper bound constraint.
+--
+-- Probably this upper bound can be raised when dropping the dependency
+-- on d-p-p.

--- a/distributed-process-test/src/Test/Driver.hs
+++ b/distributed-process-test/src/Test/Driver.hs
@@ -9,137 +9,27 @@ module Test.Driver
     , defaultMainWith
     ) where
 
-import Test.Framework
+import Test.Tasty
+import System.Environment ( getArgs, withArgs )
 
-import Text.Regex.Posix ((=~))
-import System.Console.GetOpt
-    ( OptDescr(..), ArgDescr(..), ArgOrder(..), getOpt, usageInfo )
-import System.Exit ( exitFailure, exitSuccess )
-import System.Environment ( getArgs, getProgName )
-import Control.Monad ( foldM, when )
-import Control.Arrow (second)
-
-type TestName = String
-
-data TestOption = TestOption
-  { listTests :: Bool
-  , showHelp :: Bool
-  , testPatterns :: [String]
-  } deriving (Eq, Show)
-
--- | Default option for running test.
-defaultTestOption :: TestOption
-defaultTestOption = TestOption
-  { listTests = False
-  , showHelp = False
-  , testPatterns = []
-  }
-
--- | Options for test runner.
-optdescrs :: [OptDescr (TestOption -> TestOption)]
-optdescrs =
-    [ Option ['l'] ["list"]
-      (NoArg $ \o -> o {listTests=True})
-      "list available tests and exit"
-    , Option ['h'] ["help"]
-      (NoArg $ \o -> o {showHelp=True})
-      "show help and exit"
-    , Option ['p'] ["pattern"]
-      (ReqArg (\re o -> o {testPatterns = re : testPatterns o}) "REGEX")
-      "filter tests by regex pattern REGEX"
-    ]
-
--- | Default main.
---
--- Takes a list of 'Test' and run them. The main function built with this
--- will display brief usage when @--help@ option were given.
---
-defaultMain :: [Test] -> IO ()
-defaultMain = defaultMainWith . const . return
 
 -- | Like 'defaultMain', but for tests with extra argument
 -- passed at the time of executable invocation. Instead of calling
 -- 'getArgs', use this function when arguments from command line are
 -- required.
 --
--- Note that 'OptDescr' options @-h@, @--help@, @-l@, @--list@, and @-p@,
--- @--pattern@ are already used internally.
+-- When invoking the test program:
+--
+-- > test-program <tasty arguments> -- <other arguments>
+--
+-- '--' separates the tasty arguments from the rest.
 --
 defaultMainWith ::
-    ([String] -> IO [Test])
+    ([String] -> IO TestTree)
     -- ^ Action taking list of 'String' from stdarg and returning
     -- 'Test's to run.
     -> IO ()
-defaultMainWith act = do
+defaultMainWith tests = do
     args <- getArgs
-    myName <- getProgName
-
-    let (parsed, rest, errs) = getOpt Permute optdescrs args
-        myOpts = foldr ($) defaultTestOption parsed
-        myHeader = unlines
-            [ "Usage: " ++ myName ++ " [OPTIONS]"
-            , ""
-            , "OPTIONS:"
-            ]
-        printUsage = putStrLn $ usageInfo myHeader optdescrs
-        testFilter :: String -> Bool
-        testFilter = let pats = testPatterns myOpts in case pats of
-            [] -> const True
-            _  -> \testName -> any (testName =~) pats
-
-    tests <- act rest
-
-    when (not $ null errs) $ do
-        putStrLn "Error:"
-        mapM_ (putStrLn . ("  " ++)) errs
-        printUsage
-        exitFailure
-
-    when (showHelp myOpts) $ do
-        printUsage
-        exitSuccess
-
-    when (listTests myOpts) $ do
-        listAll tests
-        exitSuccess
-
-    foldM (runTest "" testFilter) [] tests >>= summarize
-  where
-    listAll = foldM (listOne "") ()
-    listOne prefix _ t = case t of
-        Test ti           -> putStrLn $ prefix ++ name ti
-        Group gname _ ts  -> mapM_ (listOne (prefix ++ gname ++ "/") ()) ts
-        ExtraOptions _ t' -> listOne prefix () t'
-
-    runTest :: String -> (TestName -> Bool) -> [(TestName,Result)] -> Test
-               -> IO [(TestName,Result)]
-    runTest prefix filt acc (Test ti) = do
-        let testName = prefix ++ name ti
-        if filt testName then do
-            r <- run ti
-            putStr $ "Test " ++ testName ++ ":"
-            case r of
-                Finished res -> print res >> return ((testName,res):acc)
-                _            -> error "Unhandled result type."
-          else do
-            return acc
-    -- Ignoring 'concurrently' flag...
-    runTest prefix filt acc (Group gname _conc ts) = do
-        rs <- mapM (runTest (prefix ++ gname ++ "/") filt []) ts
-        return $ concat rs ++ acc
-    runTest _ _  _ _ = error "Unhandled test type."
-
-    summarize :: [(TestName,Result)] -> IO ()
-    summarize rs =
-      if all (snd . second (== Pass)) rs then do
-        putStrLn $ "All tests passed (exactly " ++ show (length rs) ++ ")."
-        putStrLn "Test result: SUCCESS"
-      else do
-        let notPassed = filter (snd . second (/= Pass)) rs
-        putStrLn $ "Some tests failed (" ++ show (length notPassed)
-                                         ++ " of " ++ show (length rs) ++ ")."
-        mapM_ putStrLn
-            [ "Test \"" ++ n ++ "\" failed with " ++ show msg
-            | (n, msg) <- notPassed ]
-        putStrLn "Test result: FAIL"
-        exitFailure
+    let (args',rest) = break (=="--") args
+    tests (drop 1 rest) >>= withArgs args' . defaultMain

--- a/ha/Makefile
+++ b/ha/Makefile
@@ -72,10 +72,10 @@ install: build
 test: loadmero build testidentify ut it
 
 ut:
-	$(SUDO) dist/build/unit-tests/unit-tests $(TEST_LISTEN)
+	$(SUDO) dist/build/unit-tests/unit-tests --num-threads 1 -- $(TEST_LISTEN)
 
 it:
-	$(SUDO) dist/build/integration-tests/integration-tests $(TEST_LISTEN)
+	$(SUDO) dist/build/integration-tests/integration-tests --num-threads 1 -- $(TEST_LISTEN)
 
 ifdef USE_RPC
 testidentify:

--- a/ha/tests/HA/Multimap/ProcessTests.hs
+++ b/ha/tests/HA/Multimap/ProcessTests.hs
@@ -70,8 +70,8 @@ mmSDict = SerializableDict
 
 remotable [ 'mmSDict ]
 
-tests :: Network -> Test
-tests network = testSuccess "multimap" $ do
+tests :: Network -> TestTree
+tests network = testSuccess "multimap" . withTmpDirectory $ do
     lnid <- newLocalNode (getNetworkTransport network)
             $ __remoteTable remoteTable
     tryRunProcess lnid $ do

--- a/ha/tests/HA/Multimap/Tests.hs
+++ b/ha/tests/HA/Multimap/Tests.hs
@@ -11,7 +11,7 @@ import Data.ByteString.Char8 ( pack )
 import Data.List ( sort )
 import Test.Framework
 
-tests :: [Test]
+tests :: [TestTree]
 tests =
     [ pureTest "toList.fromList"
        $ let [(b0',xs)] = toList $ fromList [(b0,[b1,b2]),(b0,[b3,b4])]

--- a/ha/tests/HA/Network/Tests.hs
+++ b/ha/tests/HA/Network/Tests.hs
@@ -19,7 +19,7 @@ import Control.Distributed.Process hiding (bracket)
 import Control.Exception (bracket)
 
 
-tests :: Address -> Network -> IO [Test]
+tests :: Address -> Network -> IO [TestTree]
 tests addr network = do
     let transport = getNetworkTransport network
     return

--- a/ha/tests/HA/NodeAgent/Tests.hs
+++ b/ha/tests/HA/NodeAgent/Tests.hs
@@ -88,7 +88,7 @@ spawnLocalLink f =
      spawnLocal $ flip catch (\e -> liftIO $ throwTo self (e :: SomeException)) $ f
 
 naTest :: Network -> ([LocalNode] -> Process ()) -> IO ()
-naTest network action = do
+naTest network action = withTmpDirectory $ do
   nodes <- replicateM 3 newNode
   let nids = map localNodeId nodes
   mapM_ (initialize nids) nodes
@@ -121,7 +121,7 @@ naTest network action = do
       Ok <- updateEQNodes na 0 nids
       return ()
 
-tests :: Network -> IO [Test]
+tests :: Network -> IO [TestTree]
 tests network = do
     return
       [ testSuccess "rc-get-expiate" $ naTest network $ \_nodes -> do

--- a/ha/tests/HA/RecoverySupervisor/Tests.hs
+++ b/ha/tests/HA/RecoverySupervisor/Tests.hs
@@ -92,7 +92,7 @@ rsSDict = SerializableDict
 
 remotable [ 'rsSDict, 'testRS ]
 
-tests :: Bool -> Network -> IO [Test]
+tests :: Bool -> Network -> IO [TestTree]
 tests oneNode network = do
   putStrLn $ "Testing RecoverySupervisor " ++
               if oneNode then "with one node..."
@@ -131,7 +131,7 @@ tests oneNode network = do
     ]
 
 rsTest :: Network -> Bool -> (MC_RG RSState -> Process ()) -> IO ()
-rsTest network oneNode action = do
+rsTest network oneNode action = withTmpDirectory $ do
   let amountOfReplicas = 2
   ns@(n1:_) <-
     replicateM amountOfReplicas

--- a/ha/tests/HA/ResourceGraph/Tests.hs
+++ b/ha/tests/HA/ResourceGraph/Tests.hs
@@ -145,7 +145,7 @@ instance Relation HasA NodeB NodeA where
 rGroupTest ::
     (RGroup g, Typeable1 g)
     => Network -> g Multimap -> (ProcessId -> Process ()) -> IO ()
-rGroupTest network g p = do
+rGroupTest network g p = withTmpDirectory $ do
     lnode <- newLocalNode (getNetworkTransport network) $
 	    __remoteTable remoteTable
     tryRunProcess lnode $
@@ -174,7 +174,7 @@ sampleGraph =
     newResource (NodeA 2) .
     newResource (NodeA 1)
 
-tests :: Network -> IO [Test]
+tests :: Network -> IO [TestTree]
 tests network = do
     let g = undefined :: MC_RG Multimap
     return

--- a/mero-ha/Makefile
+++ b/mero-ha/Makefile
@@ -78,8 +78,8 @@ install: build
 
 test: build testepoch testhastate
 	make loadmero
-	$(SUDO) dist/build/unit-tests/unit-tests $(TEST_LISTEN)
-	$(SUDO) dist/build/integration-tests/integration-tests $(TEST_LISTEN)
+	$(SUDO) dist/build/unit-tests/unit-tests --num-threads 1 -- $(TEST_LISTEN)
+	$(SUDO) dist/build/integration-tests/integration-tests --num-threads 1 -- $(TEST_LISTEN)
 
 ifdef USE_RPC
 testepoch:

--- a/mero-ha/tests/Test/Integration.hs
+++ b/mero-ha/tests/Test/Integration.hs
@@ -9,16 +9,15 @@ import Test.Framework
 import HA.Network.Address ( startNetwork, parseAddress )
 import qualified HA.RecoveryCoordinator.Mero.Tests ( tests )
 
-import Control.Applicative ( (<$>) )
 import System.IO ( hSetBuffering, BufferMode(..), stdout, stderr )
 
 
 -- | Temporary wrapper for components whose unit tests have not been broken up
 -- into independent small tests.
-monolith :: String -> IO () -> IO [Test]
-monolith name t = return [withTmpDirectory $ testSuccess name t]
+monolith :: String -> IO () -> IO TestTree
+monolith name = return . testSuccess name . withTmpDirectory
 
-tests :: [String] -> IO [Test]
+tests :: [String] -> IO TestTree
 tests argv = do
     hSetBuffering stdout LineBuffering
     hSetBuffering stderr LineBuffering
@@ -27,5 +26,4 @@ tests argv = do
             _    -> error "missing ADDRESS"
         addr = maybe (error "wrong address") id $ parseAddress addr0
     network <- startNetwork addr
-    concat <$> sequence
-      [  monolith "RC" $ HA.RecoveryCoordinator.Mero.Tests.tests addr0 network ]
+    monolith "RC" $ HA.RecoveryCoordinator.Mero.Tests.tests addr0 network

--- a/mero-ha/tests/Test/Unit.hs
+++ b/mero-ha/tests/Test/Unit.hs
@@ -10,16 +10,15 @@ import qualified HA.RecoveryCoordinator.Mero.Tests ( tests )
 
 import HA.Network.Address (parseAddress, startNetwork)
 
-import Control.Applicative ((<$>))
 import System.IO
 
 
 -- | Temporary wrapper for components whose unit tests have not been broken up
 -- into independent small tests.
-monolith :: String -> IO () -> IO [Test]
-monolith name t = return [testSuccess name t]
+monolith :: String -> IO () -> IO TestTree
+monolith name = return . testSuccess name
 
-tests :: [String] -> IO [Test]
+tests :: [String] -> IO TestTree
 tests argv = do
     hSetBuffering stdout LineBuffering
     hSetBuffering stderr LineBuffering
@@ -28,7 +27,4 @@ tests argv = do
             _    -> error "missing ADDRESS"
         addr = maybe (error "wrong address") id $ parseAddress addr0
     network <- startNetwork addr
-    concat <$> sequence
-        [
-          monolith "RC" $ HA.RecoveryCoordinator.Mero.Tests.tests addr0 network
-        ]
+    monolith "RC" $ HA.RecoveryCoordinator.Mero.Tests.tests addr0 network

--- a/replicated-log/Makefile
+++ b/replicated-log/Makefile
@@ -24,9 +24,9 @@ test:
 ifdef RANDOMIZED_TESTS
 	dist/build/random/random
 else
-	dist/build/tests/tests -p ut
-	dist/build/tests/tests -p durability FirstPass
-	dist/build/tests/tests -p durability SecondPass
+	dist/build/tests/tests --pattern ut --num-threads 1
+	dist/build/tests/tests --pattern durability --num-threads 1 -- FirstPass
+	dist/build/tests/tests --pattern durability --num-threads 1 -- SecondPass
 endif
 
 ci: build test install haddock 


### PR DESCRIPTION
*Created by: facundominguez*

This is implemented by having distributed-process-tests implemented
on top of tasty rather than Cabal.

The API changes are in withTmpDirectory which works over IO computations
rather than tests, and defaultMainWith which now requires tasty
arguments to be separated from tests with a '--' separator. Ideally we
should use tasty options to define custom command line arguments, this
is still pending.
