### PR TITLE
Allow to run make ci without mero.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,13 @@ $(SANDBOX_SCHED_DB):
 	cp -r $(SANDBOX_REGULAR_DB)/* $(SANDBOX_SCHED_DB)
 
 .PHONY: $(NTR_DB_DIR)
+ifneq ($(MERO_ROOT),--)
 $(NTR_DB_DIR):
 	sudo rm -rf $@
 	mkdir $@
+else
+$(NTR_DB_DIR):
+endif
 
 mero-ha: ha
 ha: replicated-log

--- a/README
+++ b/README
@@ -16,7 +16,8 @@ Prequisites:
 
 Environment variables:
 
-  MERO_ROOT Must point to the root of the mero source and build tree.
+  MERO_ROOT Must point to the root of the mero source and build tree, or must be
+            "--" to build and test without using mero.
 
   GENDERS   Must point to a genders file describing the current host and perhaps
             others. See mero-ha/scripts/genders-parsci for an example. The file

--- a/ha/Makefile
+++ b/ha/Makefile
@@ -24,9 +24,10 @@ DEBUG =
 -include mk/config.mk
 
 ifndef MERO_ROOT
-$(error The variable MERO_ROOT is undefined. Please, make it point to the mero build tree.)
+$(error The variable MERO_ROOT is undefined. Please, make it point to the mero build tree or set to -- to work without mero.)
 endif
 
+ifneq ($(MERO_ROOT),--)
 empty :=
 space := $(empty) $(empty)
 export LD_LIBRARY_PATH := \
@@ -35,8 +36,11 @@ export LD_LIBRARY_PATH := \
 		$(MERO_ROOT)/extra-libs/cunit/CUnit/Sources/.libs\
 		$(MERO_ROOT)/extra-libs/galois/src/.libs\
                 $(LD_LIBRARY_PATH)))
-
 SUDO = sudo -E LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)
+else
+SUDO =
+endif
+
 
 ifdef USE_TCP
 TEST_LISTEN = 127.0.0.1:8090

--- a/mero-ha/Makefile
+++ b/mero-ha/Makefile
@@ -24,9 +24,10 @@ DEBUG =
 -include mk/config.mk
 
 ifndef MERO_ROOT
-$(error The variable MERO_ROOT is undefined. Please, make it point to the mero build tree.)
+$(error The variable MERO_ROOT is undefined. Please, make it point to the mero build tree or set to -- to work without mero.)
 endif
 
+ifneq ($(MERO_ROOT),--)
 empty :=
 space := $(empty) $(empty)
 export LD_LIBRARY_PATH := \
@@ -35,8 +36,10 @@ export LD_LIBRARY_PATH := \
 		$(MERO_ROOT)/extra-libs/cunit/CUnit/Sources/.libs\
 		$(MERO_ROOT)/extra-libs/galois/src/.libs\
                 $(LD_LIBRARY_PATH)))
-
 SUDO = sudo -E LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)
+else
+SUDO =
+endif
 
 ifdef USE_TCP
 TEST_LISTEN = 127.0.0.1:8090
@@ -116,11 +119,14 @@ ha-node-agent:
 ha-station:
 	$(SUDO) scripts/ha station $(ARGS)
 
-clean: cleanglobaldb cleanlocaldb
+clean: cleanglobaldb cleanlocaldb clean_hastate
 	cabal clean
-	make -C hastate clean
 	rm -rf dummy_mero.stdout
 	rm -rf dummy_mero.pid
+
+ifneq ($(MERO_ROOT),--)
+clean_hastate:
+	make -C hastate clean
 
 cleanlocaldb:
 	${SUDO} rm -rf m0.trace.* *rpclite.db* *rpclite2* tmp-HA*
@@ -135,5 +141,12 @@ loadmero:
 
 unloadmero:
 	$(SUDO) M0_CORE_DIR=$(MERO_ROOT) ../network-transport-rpc/rpclite/st rmmod
+else
+clean_hastate:
+cleanlocaldb:
+cleanglobaldb:
+loadmero:
+unloadmero:
+endif
 
 ci: clean install haddock test


### PR DESCRIPTION
*Created by: facundominguez*

Before this patch, make ci would complain that MERO_ROOT was undefined.
After this patch, calling "make MERO_ROOT=-- ci" will run all tests that
can be run without using mero.
