### PR TITLE
Use vendor/distributed-process-platform as dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,8 @@ ci clean install: mero-ha
 
 dep:
 	cabal sandbox init --sandbox=$(SANDBOX_REGULAR)
-#	cabal sandbox add-source vendor/distributed-process
-	cabal install --enable-tests --only-dependencies $(CABAL_FLAGS) --reorder-goals vendor/distributed-process-platform/ distributed-process-scheduler/ distributed-process-test/ distributed-process-trans/ consensus/ consensus-paxos/ replicated-log/ network-transport-rpc/ confc/ ha/ mero-ha/
-	cabal install vendor/distributed-process-platform/ --force-reinstalls
+	cabal sandbox add-source vendor/distributed-process-platform
+	cabal install --enable-tests --only-dependencies $(CABAL_FLAGS) --reorder-goals distributed-process-scheduler/ distributed-process-test/ distributed-process-trans/ consensus/ consensus-paxos/ replicated-log/ network-transport-rpc/ confc/ ha/ mero-ha/
 
 # This target will generate distributable packages based on
 # the checked-in master branch of this repository.


### PR DESCRIPTION
*Created by: mietek*

Fixes potential bug with `--force-reinstalls`
