### PR TITLE
Clips dependency on d-p-p

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ ci clean install: mero-ha
 
 dep:
 	cabal sandbox init --sandbox=$(SANDBOX_REGULAR)
-	cabal sandbox add-source vendor/distributed-process-platform
 	cabal install --enable-tests --only-dependencies $(CABAL_FLAGS) --reorder-goals distributed-process-scheduler/ distributed-process-test/ distributed-process-trans/ consensus/ consensus-paxos/ replicated-log/ network-transport-rpc/ confc/ ha/ mero-ha/
 
 # This target will generate distributable packages based on

--- a/ha/ha.cabal
+++ b/ha/ha.cabal
@@ -44,6 +44,7 @@ Library
                       TupleSections
   Ghc-Options:     -O -Wall -Werror
   Exposed-Modules: HA.Call
+                   HA.Process
                    HA.Resources
                    HA.EventQueue
                    HA.EventQueue.Consumer
@@ -135,7 +136,6 @@ Test-Suite unit-tests
                     binary >= 0.6.4,
                     bytestring,
                     distributed-process >= 0.4,
-                    distributed-process-platform,
                     distributed-process-test,
                     distributed-static,
                     hashable,
@@ -166,7 +166,6 @@ Test-Suite integration-tests
                     bytestring,
                     Cabal >= 1.16,
                     distributed-process >= 0.4,
-                    distributed-process-platform,
                     distributed-process-test,
                     distributed-static,
                     hashable,

--- a/ha/src/lib/HA/Process.hs
+++ b/ha/src/lib/HA/Process.hs
@@ -1,0 +1,21 @@
+-- |
+-- Copyright : (C) 2014 Xyratex Technology Limited.
+-- License   : All rights reserved.
+--
+-- Convenience functions use 'Process'.
+--
+
+module HA.Process where
+
+import Control.Distributed.Process
+import Control.Distributed.Process.Internal.Types (LocalNode)
+import Control.Distributed.Process.Node (runProcess)
+
+import Control.Concurrent (myThreadId, throwTo)
+import Control.Exception (SomeException)
+
+-- | Taken from "Control.Distributed.Process.Platform.Test".
+tryRunProcess :: LocalNode -> Process () -> IO ()
+tryRunProcess node p = do
+  tid <- liftIO myThreadId
+  runProcess node $ catch p (\e -> liftIO $ throwTo tid (e::SomeException))

--- a/ha/tests/HA/Multimap/ProcessTests.hs
+++ b/ha/tests/HA/Multimap/ProcessTests.hs
@@ -17,6 +17,7 @@ import HA.Network.Address ( Network, getNetworkTransport )
 import HA.Multimap.Process ( multimap )
 import HA.Multimap ( StoreUpdate(..), updateStore, getKeyValuePairs )
 import HA.Multimap.Implementation ( fromList, Multimap )
+import HA.Process
 import HA.Replicator ( RGroup(..) )
 #ifdef USE_MOCK_REPLICATOR
 import HA.Replicator.Mock ( MC_RG )
@@ -31,7 +32,6 @@ import Control.Distributed.Process
     )
 import Control.Distributed.Process.Closure ( mkStatic, remotable )
 import Control.Distributed.Process.Node ( newLocalNode, closeLocalNode )
-import Control.Distributed.Process.Platform.Test ( tryRunProcess )
 import Control.Distributed.Process.Serializable ( SerializableDict(..) )
 
 import Control.Concurrent ( MVar, newEmptyMVar, putMVar, takeMVar, threadDelay )

--- a/ha/tests/HA/NodeAgent/Tests.hs
+++ b/ha/tests/HA/NodeAgent/Tests.hs
@@ -11,6 +11,7 @@ module HA.NodeAgent.Tests ( tests ) where
 import HA.Resources (serviceProcess)
 import HA.NodeAgent (nodeAgent,updateEQNodes, Result(..))
 import HA.Network.Address ( Network, getNetworkTransport )
+import HA.Process
 import HA.EventQueue ( eventQueue, EventQueue )
 import HA.Replicator ( RGroup(..) )
 #ifdef USE_MOCK_REPLICATOR
@@ -33,7 +34,6 @@ import Control.Distributed.Static ( closureApply )
 import Control.Distributed.Process.Closure ( mkStatic, mkClosure, remotable )
 import Control.Distributed.Process.Node ( LocalNode, localNodeId, newLocalNode, closeLocalNode )
 import Control.Distributed.Process.Internal.Primitives ( unClosure )
-import Control.Distributed.Process.Platform.Test ( tryRunProcess )
 import Control.Distributed.Process.Serializable ( SerializableDict(..) )
 
 import Data.List (find)

--- a/ha/tests/HA/RecoverySupervisor/Tests.hs
+++ b/ha/tests/HA/RecoverySupervisor/Tests.hs
@@ -10,6 +10,7 @@
 module HA.RecoverySupervisor.Tests ( tests ) where
 
 import HA.Network.Address ( Network, getNetworkTransport )
+import HA.Process
 import HA.RecoverySupervisor ( recoverySupervisor, RSState(..), pollingPeriod
                              )
 import HA.Replicator ( RGroup(..) )
@@ -33,7 +34,6 @@ import Control.Distributed.Static ( closureApply )
 import Control.Distributed.Process.Internal.Types
            ( ProcessExitException, localNodeId )
 import Control.Distributed.Process.Node ( newLocalNode, closeLocalNode )
-import Control.Distributed.Process.Platform.Test ( tryRunProcess )
 import Control.Distributed.Process.Serializable ( SerializableDict(..) )
 
 import Control.Concurrent ( MVar, newEmptyMVar, putMVar, takeMVar, threadDelay )

--- a/ha/tests/HA/ResourceGraph/Tests.hs
+++ b/ha/tests/HA/ResourceGraph/Tests.hs
@@ -16,6 +16,7 @@ import HA.Network.Address ( Network, getNetworkTransport )
 import HA.Multimap.Process ( multimap )
 import HA.Multimap ( getKeyValuePairs )
 import HA.Multimap.Implementation ( fromList, Multimap )
+import HA.Process
 import HA.ResourceGraph
 import HA.Replicator ( RGroup(..) )
 #ifdef USE_MOCK_REPLICATOR
@@ -30,7 +31,6 @@ import Control.Distributed.Process
 import Control.Distributed.Process.Closure ( remotable, mkStatic )
 import Control.Distributed.Process.Serializable ( SerializableDict(..) )
 import Control.Distributed.Process.Node ( newLocalNode, closeLocalNode )
-import Control.Distributed.Process.Platform.Test ( tryRunProcess )
 
 import Control.Concurrent ( MVar, newEmptyMVar, putMVar, takeMVar, threadDelay )
 import Control.Exception ( SomeException )

--- a/mero-ha/mero-ha.cabal
+++ b/mero-ha/mero-ha.cabal
@@ -98,7 +98,7 @@ Executable ha-station
                       mero-ha,
                       base >= 4.5,
                       distributed-process >= 0.4,
-                      filepath >= 1.3, distributed-process-platform,
+                      filepath >= 1.3,
                       network-transport >= 0.3
   if flag(rpc)
       Build-Depends: network-transport-rpc >= 0.0.1
@@ -128,7 +128,7 @@ Executable ha-node-agent
                       base >= 4.5,
                       distributed-process >= 0.4,
                       filepath >= 1.3,
-                      network-transport >= 0.3, distributed-process-platform >= 0.1
+                      network-transport >= 0.3
   if flag(rpc)
       Build-Depends: network-transport-rpc >= 0.0.1
   else
@@ -196,7 +196,6 @@ Test-Suite unit-tests
                     binary >= 0.6.4,
                     bytestring,
                     distributed-process >= 0.4,
-                    distributed-process-platform,
                     distributed-process-test,
                     distributed-static,
                     hashable,
@@ -228,7 +227,6 @@ Test-Suite integration-tests
                     bytestring,
                     Cabal >= 1.16,
                     distributed-process >= 0.4,
-                    distributed-process-platform,
                     distributed-process-test,
                     distributed-static,
                     hashable,

--- a/mero-ha/src/node/Main.hs
+++ b/mero-ha/src/node/Main.hs
@@ -7,13 +7,13 @@ module Main (main) where
 
 import Flags
 import HA.NodeAgent (nodeAgent, serviceProcess)
+import HA.Process
 import Control.Distributed.Process
 import Control.Distributed.Process.Node (newLocalNode)
 import System.Environment
 import Control.Applicative ((<$>))
 import HA.Network.Address
 import HA.NodeAgent.Lookup (advertiseNodeAgent)
-import Control.Distributed.Process.Platform.Test (tryRunProcess)
 import HA.Network.RemoteTables (haRemoteTable)
 import Mero.RemoteTables (meroRemoteTable)
 import Control.Distributed.Process.Node	(initRemoteTable)

--- a/mero-ha/src/station/Main.hs
+++ b/mero-ha/src/station/Main.hs
@@ -7,12 +7,12 @@ module Main (main) where
 
 import Flags
 import HA.NodeAgent.Lookup (lookupNodeAgent)
+import HA.Process
 import System.Environment
 import Control.Applicative ((<$>))
 import Control.Distributed.Process.Closure ( mkClosure, functionTDict )
 import Control.Distributed.Process
 import HA.Network.Address
-import Control.Distributed.Process.Platform.Test (tryRunProcess)
 import Control.Distributed.Process.Node (newLocalNode)
 import HA.RecoveryCoordinator.Mero.Startup
 import HA.Network.RemoteTables (haRemoteTable)


### PR DESCRIPTION
*Created by: facundominguez*

It adds a commit on top of #10 to drop the dependency on d-p-p.

I couldn't figure out how to get rid of the vendor/d-p-p submodule. Probably I'd need a newer git which implements git submodule deinit.
