### PR TITLE
Publish RC address to the colocated EQ.

### DIFF
--- a/mero-ha/src/lib/HA/RecoveryCoordinator/Mero/Startup.hs
+++ b/mero-ha/src/lib/HA/RecoveryCoordinator/Mero/Startup.hs
@@ -126,6 +126,7 @@ remotableDecl [ [d|
                        link rcpid
                        multimap (viewRState $(mkStatic 'multimapView) rGroup)
                 rcpid <- spawnLocal (recoveryCoordinator eqpid mmpid args)
+                send eqpid rcpid
                 liftIO $ putMVar mRCPid rcpid
                 return rcpid
 


### PR DESCRIPTION
*Created by: qnikst*

Colocated EQ relies in on the publishing of RS address, but
thats never happens. This commit fixes this situation by publishing
address of the EQ.
