### PR TITLE
Extend na-eq timeout

### DIFF
--- a/ha/src/lib/HA/NodeAgent.hs
+++ b/ha/src/lib/HA/NodeAgent.hs
@@ -226,7 +226,7 @@ remotableDecl [ [d|
                     when (null $ nasReplicas nas) $ say $
                         "Warning: service event cannot proceed, since \
                         \no event queues are registed in the node agent"
-                    let timeOut = 1000000
+                    let timeOut = 3000000
                         ev = HAEvent { eventId = EventId self $ nasEventCounter nas
                                      , eventPayload = content :: [ByteString] }
                     -- When there is an unreachable preferred replica we must


### PR DESCRIPTION
*Created by: facundominguez*

Based on top of path-compression to avoid merge conflicts.

Timeouts would occur with a perfectly working network since the EQs cannot respond so fast most of the time.
