### PR TITLE
Allow anonymous access to submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/distributed-process"]
 	path = vendor/distributed-process
-	url = git@github.com:haskell-distributed/distributed-process.git
+	url = https://github.com/haskell-distributed/distributed-process.git


### PR DESCRIPTION
*Created by: nc6*

The build user on Xyratex internal CI does not have a github account, and hence cannot clone using the `git@github.com` ssh access. Switch to using anonymous http access instead.
