### PR TITLE
Revert ha->halon in #include statements.

### DIFF
--- a/mero-halon/hastate/dummy_mero.c
+++ b/mero-halon/hastate/dummy_mero.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "conf/confc.h"
-#include "halon/note.h"
+#include "ha/note.h"
 #include "rpclite.h"
 
 static struct m0_confc confc;

--- a/mero-halon/hastate/hastate.c
+++ b/mero-halon/hastate/hastate.c
@@ -10,7 +10,7 @@
 #include "hastate_fops.h"
 
 #include "fop/fop.h"
-#include "halon/note_fops.h"
+#include "ha/note_fops.h"
 #include "lib/memory.h"
 
 #include "hastate_foms.h"

--- a/mero-halon/hastate/hastate.h
+++ b/mero-halon/hastate/hastate.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "halon/note.h"
+#include "ha/note.h"
 #include "rpclite.h"
 
 /// Callbacks for handling requests made with m0_ha_state_get and m0_ha_state_set.

--- a/mero-halon/hastate/hastate_foms.c
+++ b/mero-halon/hastate/hastate_foms.c
@@ -5,7 +5,7 @@
 
 #include "fop/fom.h"
 #include "fop/fom_generic.h"
-#include "halon/note_fops.h"
+#include "ha/note_fops.h"
 #include "lib/errno.h"
 #include "lib/memory.h"
 #include "lib/trace.h"

--- a/mero-halon/hastate/hastate_fops.c
+++ b/mero-halon/hastate/hastate_fops.c
@@ -5,9 +5,9 @@
 
 #include "fop/fom_generic.h"
 #include "fop/fop.h"
-#include "halon/note_xc.h"
-#include "halon/note_fops.h"
-#include "halon/note_fops_xc.h"
+#include "ha/note_xc.h"
+#include "ha/note_fops.h"
+#include "ha/note_fops_xc.h"
 #include "rpc/rpc.h"
 #include "rpc/rpc_opcodes.h"
 

--- a/network-transport-rpc/rpclite/dummyService.c
+++ b/network-transport-rpc/rpclite/dummyService.c
@@ -7,7 +7,7 @@
 */
 
 #include "rpclite.h"
-#include "halon/epoch.h"
+#include "ha/epoch.h"
 #include "fop/fop.h"
 #include "rpclite_fom.h"
 #include <stdio.h>

--- a/network-transport-rpc/rpclite/rpclite.c
+++ b/network-transport-rpc/rpclite/rpclite.c
@@ -26,7 +26,7 @@
 #include "reqh/reqh.h"  /* m0_reqh_rpc_mach_tl */
 #include "rpclite_fop_ff.h"
 
-#include "halon/epoch.h"
+#include "ha/epoch.h"
 
 #include "ut/cs_fop_foms.c"
 #include "ut/cs_fop_foms_xc.c"


### PR DESCRIPTION
*Created by: nc6*

Breaks USE_RPC.
