### PR TITLE
`hostname -i` is a bad way to get IP.

### DIFF
--- a/mero-halon/scripts/halon
+++ b/mero-halon/scripts/halon
@@ -46,7 +46,9 @@ function getaddr_rpc
 function getaddr
 {
   # Stores the local IP address
-  IP="$(hostname -i)"
+  if [ -z "$IP" ]; then
+    IP="$(hostname -i)"
+  fi
 
   [ -z "$IP" ] && err "Can't find a local IP address"
 


### PR DESCRIPTION
*Created by: nc6*

Leave it for now, but allow it to be overridden.
