### PR TITLE
Various fixes for the buildsystem patch

### DIFF
--- a/confc/Makefile
+++ b/confc/Makefile
@@ -1,4 +1,6 @@
 
+CABAL = cabal $(CABAL_SANDBOX)
+
 ifndef MERO_ROOT
 $(error The variable MERO_ROOT is undefined. Please, make it point to the mero build tree.)
 endif
@@ -30,18 +32,17 @@ export LDFLAGS
 CONFIGURE_FLAGS:=--extra-include-dirs=$(MERO_ROOT) --extra-include-dirs=$(MERO_ROOT)/extra-libs/db4/build_unix $(HLD_SEARCH_PATH) $(PROF_FLAGS) $(DEBUG_FLAGS)
 
 build: configure
-	cabal build
+	$(CABAL) build
 
 install: build
-	cabal copy
-	cabal register
+	$(CABAL) copy
+	$(CABAL) register
 
 haddock: configure
-	cabal haddock
+	$(CABAL) haddock
 
 configure:
-	cabal sandbox init --sandbox=$(SANDBOX)
-	cabal configure --enable-tests $(CONFIGURE_FLAGS)
+	$(CABAL) configure --enable-tests $(CONFIGURE_FLAGS)
 
 test: build
 	sudo -E $(ENV) $(RPCLITE_PREFIX)/st sstart confd
@@ -67,7 +68,7 @@ loadmero:
 
 clean:
 	make -C ctests clean
-	cabal clean
+	$(CABAL) clean
 	rm -f rpclite_fop_ff.h
 	rm -f rpclite_fop_ff.c
 	sudo rm -rf m0.trace*

--- a/consensus-paxos/Makefile
+++ b/consensus-paxos/Makefile
@@ -1,48 +1,42 @@
+CABAL = cabal $(CABAL_SANDBOX)
 ifdef RANDOMIZED_TESTS
-BUILDDIR = dist-schedule
-TEST     = $(BUILDDIR)/build/random/random
+TEST     = dist-scheduler/build/random/random
+CABAL   += --builddir=dist-scheduler
 CABAL_FLAGS  += -frandomTests
 else
-BUILDDIR = dist
-TEST     = $(BUILDDIR)/build/tests/tests
+TEST    = dist/build/tests/tests
 endif
-CABAL_FLAGS  += --builddir=$(BUILDDIR)
 
 build: configure
-	cabal build --builddir=$(BUILDDIR)
+	$(CABAL) build
 
-configure: sandbox
-	cabal configure --enable-tests $(CABAL_FLAGS)
+configure: dep 
+	$(CABAL) configure --enable-tests $(CABAL_FLAGS)
 
 clean:
-	cabal clean --builddir=$(BUILDDIR)
+	$(CABAL) clean
 
 install: build
-	cabal copy --builddir=$(BUILDDIR)
-	cabal register --builddir=$(BUILDDIR)
+	$(CABAL) copy
+	$(CABAL) register
 
 haddock:
-	cabal haddock --builddir=$(BUILDDIR)
+	$(CABAL) haddock
 
-sandbox: 
-	@echo "Preparing sandbox"
-	cabal sandbox init --sandbox=$(SANDBOX)
-	cabal sandbox add-source \
-		../distributed-process-scheduler \
-		../distributed-process-test \
-		../consensus
+dep:
 ifdef RANDOMIZED_TESTS
 	@echo "Installing distributed-process-scheduler with scheduler enabled"
-	cabal install distributed-process-scheduler -fuse-scheduler
+	-$(CABAL) $(CABAL_FLAGS) install distributed-process-scheduler -fuse-scheduler
 endif
-	cabal install --only-dependencies --enable-tests --reorder-goals || echo "it not required"
+	-$(CABAL) install --only-dependencies --enable-tests --reorder-goals
+
 
 test: $(TEST)
+	$(TEST)
 
 $(TEST): build
-	$(TEST)
 
 promela:
 	make -C promela test
 
-ci: build test install promela haddock
+ci: clean build test install promela haddock

--- a/consensus/Makefile
+++ b/consensus/Makefile
@@ -1,28 +1,29 @@
+CABAL = cabal $(CABAL_SANDBOX)
 
 build: configure
-	cabal build
+	$(CABAL) build
 
-configure:
-	cabal clean
-	cabal configure --enable-tests
+configure: dep
+	$(CABAL) configure --enable-tests
 
-sandbox:
+dep:
 	@echo "Preparing sandbox"
-	cabal sandbox init --sandbox=$(SANDBOX)
-	cabal sandbox add-source \
-		../distributed-process-scheduler
-	cabal install --only-dependencies --enable-tests --reorder-goals || echo "already installed"
+ifdef RANDOMIZED_TESTS
+	@echo "Installing distributed-process-scheduler with scheduler enabled"
+	-$(CABAL) $(CABAL_FLAGS) install distributed-process-scheduler -fuse-scheduler
+endif
+	-$(CABAL) install --only-dependencies --enable-tests --reorder-goals
 
 clean:
-	cabal clean
+	$(CABAL) clean
 
 install: build
-	cabal copy
-	cabal register
+	$(CABAL) copy
+	$(CABAL) register
 
 haddock:
-	cabal haddock
+	$(CABAL) haddock
 
-test: sandbox build 
+test:
 
-ci: build test install haddock 
+ci: clean build test install haddock 

--- a/distributed-process-scheduler/Makefile
+++ b/distributed-process-scheduler/Makefile
@@ -1,35 +1,35 @@
+CABAL = cabal $(CABAL_SANDBOX)
 ifdef RANDOMIZED_TESTS
-BUILDDIR=dist-schedule
+CABAL += --builddir=dist-scheduler
 CABAL_FLAGS += -fuse-scheduler
+TEST = dist-scheduler/build/unit-tests/unit-tests
 else
-BUILDDIR=dist
+TEST = dist/build/unit-tests/unit-tests
 endif
-CABAL_FLAGS += --builddir=$(BUILDDIR)
 
 
-build: sandbox configure
-	cabal build --builddir=$(BUILDDIR)
+build: configure
+	$(CABAL) build
 
-sandbox:
-	cabal sandbox init --sandbox=$(SANDBOX)
-	cabal sandbox add-source \
-		../distributed-process-trans --snapshot
-	cabal install --only-dependencies --enable-tests --reorder-goals || echo "is not required"
+dep:
+	-$(CABAL) install --only-dependencies --enable-tests --reorder-goals
 
-configure:
-	cabal configure --enable-tests $(CABAL_FLAGS)
+configure: dep
+	$(CABAL) configure --enable-tests $(CABAL_FLAGS)
 
 clean:
-	cabal clean --builddir=$(BUILDDIR)
+	$(CABAL) clean
 
 install: build
-	cabal copy --builddir=$(BUILDDIR)
-	cabal register --builddir=$(BUILDDIR)
+	$(CABAL) copy
+	$(CABAL) register
 
 haddock:
-	cabal haddock --builddir=$(BUILDDIR)
+	$(CABAL) haddock
 
-test: build 
-	$(BUILDDIR)/build/unit-tests/unit-tests
+$(TEST): build
 
-ci: build test install haddock 
+test: $(TEST)
+	$(TEST)
+
+ci: clean build test install haddock 

--- a/distributed-process-test/Makefile
+++ b/distributed-process-test/Makefile
@@ -1,25 +1,29 @@
-build: sandbox configure
-	cabal build
+CABAL = cabal $(CABAL_SANDBOX)
+ifdef RANDOMIZED_TESTS
+CABAL += --builddir=dist-scheduer
+CABAL_FLAGS += -fuse-scheduler
+endif
 
-sandbox:
-	cabal sandbox init --sandbox=$(SANDBOX)
+build: configure
+	$(CABAL) build
 
-configure: sandbox
-	cabal configure --enable-tests
+deps:
+	-$(CABAL) install --enable-tests --only-dependencies
+
+configure: deps
+	$(CABAL) configure --enable-tests
 
 clean:
-	cabal clean
+	$(CABAL) clean
 
 
 install: build
-	cabal copy
-	cabal register
+	$(CABAL) copy
+	$(CABAL) register
 
 haddock:
-	cabal haddock
+	$(CABAL) haddock
 
-test-and-install: test install
-
-test: configure
+test: 
 
 ci: clean build test install haddock

--- a/distributed-process-trans/Makefile
+++ b/distributed-process-trans/Makefile
@@ -1,23 +1,24 @@
+CABAL = cabal $(CABAL_SANDBOX)
 
 build: configure
-	cabal build
+	$(CABAL) build
 
-sandbox:
-	cabal sandbox init --sandbox=$(SANDBOX)
+configure: deps
+	$(CABAL) configure --enable-tests
 
-configure: sandbox
-	cabal configure --enable-tests
+deps:
+	-$(CABAL) install --enable-tests --dependencies-only
 
 clean:
-	cabal clean
+	$(CABAL) clean
 
 install: build
-	cabal copy
-	cabal register
+	$(CABAL) copy
+	$(CABAL) register
 
 haddock:
-	cabal haddock
+	$(CABAL) haddock
 
-test: build 
+test:
 
 ci: clean build test install haddock 

--- a/halon/Makefile
+++ b/halon/Makefile
@@ -64,12 +64,14 @@ endif
 # explicitly, but is available in the environment of recipes.
 export GENDERS
 
+CABAL = cabal $(CABAL_SANDBOX)
+
 build: configure
-	cabal build
+	$(CABAL) build
 
 install: build
-	cabal copy
-	cabal register
+	$(CABAL) copy
+	$(CABAL) register
 
 .PHONY: test loadmero build testidentify ut it
 
@@ -98,19 +100,16 @@ loadmero:
 endif
 
 haddock: configure
-	cabal haddock
+	$(CABAL) haddock
 
 
-sandbox: 
-	cabal sandbox init --sandbox=$(SANDBOX)
-	cabal sandbox add-source \
-		../replicated-log
-	cabal install --only-dependencies --enable-tests --reorder-goals || echo "not installing"
+dep: 
+	-$(CABAL) install --only-dependencies --enable-tests --reorder-goals
 
-configure: sandbox
-	cabal configure $(CABAL_FLAGS)
+configure: dep 
+	$(CABAL) configure $(CABAL_FLAGS)
 
 clean:
-	cabal clean
+	$(CABAL) clean
 
 ci: clean install haddock test

--- a/mero-halon/Makefile
+++ b/mero-halon/Makefile
@@ -66,6 +66,7 @@ endif
 ifdef DEBUG
 CABAL_FLAGS += -fdebug --enable-tests
 endif
+CABAL = cabal $(CABAL_SANDBOX)
 
 # This variable is required to be set on the command line or in the
 # environment. As such, this variable does not need to be exported
@@ -73,11 +74,11 @@ endif
 export GENDERS
 
 build: configure
-	cabal build
+	$(CABAL) build
 
 install: build
-	cabal copy
-	cabal register
+	$(CABAL) copy
+	$(CABAL) register
 
 test: build testepoch testhastate
 	make loadmero
@@ -107,16 +108,13 @@ testhastate:
 endif
 
 haddock: configure
-	cabal haddock
+	$(CABAL) haddock
 
-sandbox:
-	cabal sandbox init --sandbox=$(SANDBOX)
-	cabal sandbox add-source \
-		../halon
-	cabal install --only-dependencies || echo "not installing"
+dep:
+	-$(CABAL) install --enable-tests --only-dependencies
 
-configure: sandbox
-	cabal configure $(CABAL_FLAGS)
+configure: dep
+	$(CABAL) configure $(CABAL_FLAGS)
 
 halon-node-agent:
 	$(SUDO) scripts/halon node-agent
@@ -125,7 +123,7 @@ halon-station:
 	$(SUDO) scripts/halon station $(ARGS)
 
 clean: cleanglobaldb cleanlocaldb clean_hastate
-	cabal clean
+	$(CABAL) clean
 	rm -rf dummy_mero.stdout
 	rm -rf dummy_mero.pid
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -23,9 +23,25 @@ CABAL_FLAGS = --package-db=clean
 
 GHC_VERSION = $(shell ghc --numeric-version)
 
-SANDBOX_DEFAULT = $(shell pwd)/.cabal-sandbox
-SANDBOX_DEFAULT_DB = $(shell pwd)/.cabal-sandbox/x86_64-linux-ghc-$(GHC_VERSION)-packages.conf.d
+SANDBOX_DEFAULT = $(shell pwd)/.cabal-sandbox-default
+SANDBOX_DEFAULT_CONFIG = $(shell pwd)/cabal.sandbox-default.config
+CABAL_DEFAULT_SANDBOX  = --sandbox-config-file=$(SANDBOX_DEFAULT_CONFIG)
 
 # When building with the scheduler enabled, use a different sandbox.
 SANDBOX_SCHED = $(shell pwd)/.cabal-sandbox-scheduler
-SANDBOX_SCHED_DB = $(SANDBOX_SCHED)/x86_64-linux-ghc-$(GHC_VERSION)-packages.conf.d
+SANDBOX_SCHED_CONFIG = $(shell pwd)/cabal.sandbox-scheduler.config
+CABAL_SCHED_SANDBOX  = --sandbox-config-file=$(SANDBOX_SCHED_CONFIG)
+
+PACKAGES = $(ROOT_DIR)/distributed-process-scheduler/ \
+           $(ROOT_DIR)/distributed-process-test/ \
+           $(ROOT_DIR)/distributed-process-trans/ \
+           $(ROOT_DIR)/consensus/ \
+           $(ROOT_DIR)/consensus-paxos/ \
+           $(ROOT_DIR)/replicated-log/ \
+           $(ROOT_DIR)/network-transport-rpc/ \
+           $(ROOT_DIR)/confc/ \
+           $(ROOT_DIR)/halon/ \
+           $(ROOT_DIR)/mero-halon/
+
+VENDOR_PACKAGES = $(ROOT_DIR)/vendor/distributed-process \
+                  $(ROOT_DIR)/vendor/tasty-files

--- a/network-transport-rpc/Makefile
+++ b/network-transport-rpc/Makefile
@@ -1,3 +1,4 @@
+CABAL = cabal $(CABAL_SANDBOX)
 
 ifndef MERO_ROOT
 $(error The variable MERO_ROOT is undefined. Please, make it point to the mero build tree.)
@@ -37,19 +38,18 @@ LDFLAGS=$(LD_SEARCH_PATH) -lmero
 CONFIGURE_FLAGS:=$(EXTRAINCLUDE) $(HLD_SEARCH_PATH) $(PROF_FLAGS) $(DEBUG_FLAGS)
 
 build: configure
-	cabal build
+	$(CABAL) build
 	make -C rpclite dummyService
 
 install: build
-	cabal copy
-	cabal register
+	$(CABAL) copy
+	$(CABAL) register
 
 haddock: configure
-	cabal haddock
+	$(CABAL) haddock
 
 configure: rpclite/rpclite_fop_ff.c rpclite/rpclite_fop_ff.h
-	cabal sandbox init --sandbox=$(SANDBOX)
-	cabal configure --enable-tests $(CONFIGURE_FLAGS)
+	$(CABAL) configure --enable-tests $(CONFIGURE_FLAGS)
 
 rpclite/rpclite_fop_ff.c: rpclite/rpclite_fop.ff
 	$(FF2C) rpclite/rpclite_fop.ff
@@ -114,7 +114,7 @@ testtransport: build
 	sudo $(ENV) dist/build/testtransport/testtransport "0@lo:12345:34:2"
 
 clean:
-	cabal clean
+	$(CABAL) clean
 	cd rpclite; make clean; cd ..
 	sudo rm -rf m0.trace*
 	sudo rm -rf *.db*

--- a/replicated-log/Makefile
+++ b/replicated-log/Makefile
@@ -1,36 +1,36 @@
+CABAL = cabal $(CABAL_SANDBOX)
 ifdef RANDOMIZED_TESTS
-BUILDDIR = dist-schedule
 CABAL_FLAGS  += -frandomTests
-TEST     = $(BUILDDIR)/build/random/random
+TEST     = dist-scheduler/build/random/random
+CABAL  += --builddir=dist-scheduler
 else
-BUILDDIR = dist
-TEST     = $(BUILDDIR)/build/tests/tests
+TEST     = dist/build/tests/tests
 endif
 
-CABAL_FLAGS  += --builddir=$(BUILDDIR)
 
 build: configure
-	cabal build --builddir=$(BUILDDIR)
+	$(CABAL) build
 
-sandbox:
-	cabal sandbox init --sandbox=$(SANDBOX)
-	cabal sandbox add-source --snapshot \
-		../consensus \
-		../consensus-paxos
-	cabal install --only-dependencies --enable-tests --reorder-goals || echo "not installing"
+dep:
+ifdef RANDOMIZED_TESTS
+	@echo "Installing distributed-process-scheduler with scheduler enabled"
+	-$(CABAL) $(CABAL_FLAGS) install distributed-process-scheduler -fuse-scheduler
+endif
+	-$(CABAL) install --only-dependencies --enable-tests --reorder-goals
 
-configure: sandbox
-	cabal configure --enable-tests $(CABAL_FLAGS)
+
+configure: dep 
+	$(CABAL) configure --enable-tests $(CABAL_FLAGS)
 
 clean:
-	cabal clean --builddir=$(BUILDDIR)
+	$(CABAL) clean
 
 install: build
-	cabal copy --builddir=$(BUILDDIR)
-	cabal register --builddir=$(BUILDDIR)
+	$(CABAL) copy
+	$(CABAL) register
 
 haddock:
-	cabal haddock --builddir=$(BUILDDIR)
+	$(CABAL) haddock
 
 $(TEST): build
 


### PR DESCRIPTION
*Created by: qnikst*

The main improvement in this commit is that
we introduce 2 single toplevel sandboxes and
are able to reuse projects inside them.
