### PR TITLE
Use default arguments in tests.

### DIFF
--- a/distributed-process-test/distributed-process-test.cabal
+++ b/distributed-process-test/distributed-process-test.cabal
@@ -21,6 +21,7 @@ Library
   Default-Language: Haskell2010
   Exposed-Modules:  Test.Framework
                     Test.Driver
+                    Test.Tasty.Environment
   Build-Depends:    base >= 4.5,
                     containers,
                     data-accessor,

--- a/distributed-process-test/src/Test/Tasty/Environment.hs
+++ b/distributed-process-test/src/Test/Tasty/Environment.hs
@@ -1,0 +1,16 @@
+-- |
+-- Copyright : (C) 2013 Xyratex Technology Limited.
+-- License   : All rights reserved.
+--
+-- Helpers for 'tasty' framework.
+
+
+module Test.Tasty.Environment
+   ( parseArgs
+   ) where
+
+import System.Environment (getArgs)
+
+-- | Parse test arguments from the command line.
+parseArgs :: IO ([String], [String])
+parseArgs = fmap (fmap (drop 1) . span (/= "--")) getArgs

--- a/halon/tests/Test/Unit.hs
+++ b/halon/tests/Test/Unit.hs
@@ -17,16 +17,22 @@ import qualified HA.ResourceGraph.Tests ( tests )
 import HA.Network.Address (parseAddress, startNetwork)
 
 import Control.Applicative ((<$>))
+import System.Environment (lookupEnv)
 import System.IO
 
 tests :: [String] -> IO TestTree
 tests argv = do
     hSetBuffering stdout LineBuffering
     hSetBuffering stderr LineBuffering
-    let addr0 = case argv of
-            a0:_ -> a0
-            _    -> error "missing ADDRESS"
-        addr = maybe (error "wrong address") id $ parseAddress addr0
+    addr0 <- case argv of
+            a0:_ -> return a0
+            _    ->
+#ifdef USE_RPC
+                    maybe (error "TEST_LISTEN environment variable is not set") id <$> lookupEnv "TEST_LISTEN"
+#else
+                    maybe "localhost:0" id <$> lookupEnv "TEST_LISTEN"
+#endif
+    let addr = maybe (error "wrong address") id $ parseAddress addr0
     network <- startNetwork addr
     fmap (testGroup "ut") $ sequence
         [

--- a/mero-halon/tests/Test/Unit.hs
+++ b/mero-halon/tests/Test/Unit.hs
@@ -10,6 +10,8 @@ import qualified HA.RecoveryCoordinator.Mero.Tests ( tests )
 
 import HA.Network.Address (parseAddress, startNetwork)
 
+import Control.Applicative ((<$>))
+import System.Environment (lookupEnv)
 import System.IO
 
 
@@ -22,9 +24,14 @@ tests :: [String] -> IO TestTree
 tests argv = do
     hSetBuffering stdout LineBuffering
     hSetBuffering stderr LineBuffering
-    let addr0 = case argv of
-            a0:_ -> a0
-            _    -> error "missing ADDRESS"
-        addr = maybe (error "wrong address") id $ parseAddress addr0
+    addr0 <- case argv of
+               a0:_ -> return a0
+               _ ->
+#ifdef USE_RPC
+                 maybe (error "environement variable TEST_LISTEN is not set") id <$> lookupEnv "TEST_LISTEN"  
+#else
+                 maybe "localhost:0" id <$> lookupEnv "TEST_LISTEN"
+#endif
+    let addr = maybe (error "wrong address") id $ parseAddress addr0
     network <- startNetwork addr
     monolith "RC" $ HA.RecoveryCoordinator.Mero.Tests.tests addr0 network

--- a/replicated-log/tests/ut.hs
+++ b/replicated-log/tests/ut.hs
@@ -5,6 +5,17 @@
 import Test (tests)
 
 import Test.Driver
+import Test.Tasty.Environment
 
 main :: IO ()
-main = defaultMainWith tests
+main = do
+   (testArgs, runnerArgs) <- parseArgs
+   let runWithArgs r t = defaultMainWithArgs tests (testArgs `orDefault` t) (runnerArgs `orDefault` r)
+   -- XXX: if it is possible then move all invocation logic to the test suites.
+   runWithArgs ["--pattern","ut","--num-threads","1"] []
+   runWithArgs ["--pattern","durability","--num-threads","1"] ["FirstPass"]
+   runWithArgs ["--pattern","durability","--num-threads","1"] ["SecondPass"]
+
+orDefault :: [a] -> [a] -> [a]
+orDefault [] x = x
+orDefault x  _ = x


### PR DESCRIPTION
*Created by: qnikst*

This patch provides ability to run cabal test
even from the clean environment.
