### PR TITLE
d-p-scheduler: Print a message to stdout when the scheduler terminates because of an exception

### DIFF
--- a/distributed-process-scheduler/src/Control/Distributed/Process/Scheduler/Internal.hs
+++ b/distributed-process-scheduler/src/Control/Distributed/Process/Scheduler/Internal.hs
@@ -152,7 +152,9 @@ startScheduler initialProcs seed0 = do
                         (\pid StopScheduler -> DP.send pid SchedulerTerminated))
                       `DP.catch` (\e -> do
                          DP.exit self $ "scheduler died: " ++ show e
-                         DP.liftIO $ throwIO (e :: SomeException)
+                         DP.liftIO $ do
+                           putStrLn $ "scheduler died: " ++ show e
+                           throwIO (e :: SomeException)
                        )
            DP.liftIO $ putMVar schedulerVar spid
            return (True,())


### PR DESCRIPTION
*Created by: facundominguez*

This makes it easier to diagnose the cause of failing tests.
