### PR TITLE
Rewrite the RG representation of services.

### DIFF
--- a/halon/halon.cabal
+++ b/halon/halon.cabal
@@ -62,6 +62,7 @@ Library
                    HA.Network.Transport
                    HA.Service
                    HA.Services.Dummy
+                   HA.Services.Empty
                    HA.Services.OCF
                    Control.SpineSeq
   Build-Depends:   base,

--- a/halon/src/lib/HA/Network/RemoteTables.hs
+++ b/halon/src/lib/HA/Network/RemoteTables.hs
@@ -9,6 +9,7 @@ import HA.ResourceGraph ( __remoteTable )
 import HA.Resources ( __remoteTable )
 import HA.NodeAgent ( __remoteTable, __remoteTableDecl )
 import HA.Services.Dummy ( __remoteTable, __remoteTableDecl )
+import HA.Services.Empty ( __remoteTable )
 import HA.Service ( __remoteTable )
 import HA.Services.OCF ( __remoteTableDecl )
 import HA.RecoverySupervisor ( __remoteTable )
@@ -35,6 +36,7 @@ haRemoteTable next =
    HA.NodeAgent.__remoteTableDecl $
    HA.Services.Dummy.__remoteTable $
    HA.Services.Dummy.__remoteTableDecl $
+   HA.Services.Empty.__remoteTable $
    HA.Service.__remoteTable $
    HA.Services.OCF.__remoteTableDecl $
    HA.RecoverySupervisor.__remoteTable $

--- a/halon/src/lib/HA/Services/Dummy.hs
+++ b/halon/src/lib/HA/Services/Dummy.hs
@@ -20,7 +20,7 @@ module HA.Services.Dummy
 import HA.Service
 import HA.NodeAgent
 import HA.ResourceGraph
-import HA.Resources (Node)
+import HA.Resources (Cluster, Node)
 
 import Control.Applicative ((<$>))
 import Control.Distributed.Process
@@ -63,44 +63,77 @@ dSerializableDict = SerializableDict
 
 --TODO Can we auto-gen this whole section?
 resourceDictServiceDummy :: Dict (Resource (Service DummyConf))
+resourceDictServiceProcessDummy :: Dict (Resource (ServiceProcess DummyConf))
 resourceDictConfigItemDummy :: Dict (Resource DummyConf)
 resourceDictServiceDummy = Dict
+resourceDictServiceProcessDummy = Dict
 resourceDictConfigItemDummy = Dict
 
-relationDictHasNodeServiceDummy :: Dict (Relation Runs Node (Service DummyConf))
-relationDictWantsServiceDummyConfigItemDummy ::
-  Dict (Relation WantsConf (Service DummyConf) DummyConf)
-relationDictHasServiceDummyConfigItemDummy ::
-  Dict (Relation HasConf (Service DummyConf) DummyConf)
-relationDictHasNodeServiceDummy = Dict
-relationDictWantsServiceDummyConfigItemDummy = Dict
-relationDictHasServiceDummyConfigItemDummy = Dict
+relationDictSupportsClusterServiceDummy :: Dict (
+    Relation Supports Cluster (Service DummyConf)
+  )
+relationDictHasNodeServiceProcessDummy :: Dict (
+    Relation Runs Node (ServiceProcess DummyConf)
+  )
+relationDictWantsServiceProcessDummyConfigItemDummy :: Dict (
+    Relation WantsConf (ServiceProcess DummyConf) DummyConf
+  )
+relationDictHasServiceProcessDummyConfigItemDummy :: Dict (
+    Relation HasConf (ServiceProcess DummyConf) DummyConf
+  )
+relationDictInstanceOfServiceDummyServiceProcessDummy :: Dict (
+    Relation InstanceOf (Service DummyConf) (ServiceProcess DummyConf)
+  )
+relationDictOwnsServiceProcessDummyServiceName :: Dict (
+    Relation Owns (ServiceProcess DummyConf) ServiceName
+  )
+relationDictSupportsClusterServiceDummy = Dict
+relationDictHasNodeServiceProcessDummy = Dict
+relationDictWantsServiceProcessDummyConfigItemDummy = Dict
+relationDictHasServiceProcessDummyConfigItemDummy = Dict
+relationDictInstanceOfServiceDummyServiceProcessDummy = Dict
+relationDictOwnsServiceProcessDummyServiceName = Dict
 
 remotable
   [ 'dConfigDict
   , 'dSerializableDict
   , 'resourceDictServiceDummy
+  , 'resourceDictServiceProcessDummy
   , 'resourceDictConfigItemDummy
-  , 'relationDictHasNodeServiceDummy
-  , 'relationDictHasServiceDummyConfigItemDummy
-  , 'relationDictWantsServiceDummyConfigItemDummy
+  , 'relationDictSupportsClusterServiceDummy
+  , 'relationDictHasNodeServiceProcessDummy
+  , 'relationDictWantsServiceProcessDummyConfigItemDummy
+  , 'relationDictHasServiceProcessDummyConfigItemDummy
+  , 'relationDictInstanceOfServiceDummyServiceProcessDummy
+  , 'relationDictOwnsServiceProcessDummyServiceName
   ]
 
 instance Resource (Service DummyConf) where
   resourceDict = $(mkStatic 'resourceDictServiceDummy)
 
+instance Resource (ServiceProcess DummyConf) where
+  resourceDict = $(mkStatic 'resourceDictServiceProcessDummy)
+
 instance Resource DummyConf where
   resourceDict = $(mkStatic 'resourceDictConfigItemDummy)
 
-instance Relation Runs Node (Service DummyConf) where
-  relationDict = $(mkStatic 'relationDictHasNodeServiceDummy)
+instance Relation Supports Cluster (Service DummyConf) where
+  relationDict = $(mkStatic 'relationDictSupportsClusterServiceDummy)
 
-instance Relation HasConf (Service DummyConf) DummyConf where
-  relationDict = $(mkStatic 'relationDictHasServiceDummyConfigItemDummy)
+instance Relation Runs Node (ServiceProcess DummyConf) where
+  relationDict = $(mkStatic 'relationDictHasNodeServiceProcessDummy)
 
-instance Relation WantsConf (Service DummyConf) DummyConf where
-  relationDict = $(mkStatic 'relationDictWantsServiceDummyConfigItemDummy)
+instance Relation HasConf (ServiceProcess DummyConf) DummyConf where
+  relationDict = $(mkStatic 'relationDictHasServiceProcessDummyConfigItemDummy)
 
+instance Relation WantsConf (ServiceProcess DummyConf) DummyConf where
+  relationDict = $(mkStatic 'relationDictWantsServiceProcessDummyConfigItemDummy)
+
+instance Relation InstanceOf (Service DummyConf) (ServiceProcess DummyConf) where
+  relationDict = $(mkStatic 'relationDictInstanceOfServiceDummyServiceProcessDummy)
+
+instance Relation Owns (ServiceProcess DummyConf) ServiceName where
+  relationDict = $(mkStatic 'relationDictOwnsServiceProcessDummyServiceName)
 --------------------------------------------------------------------------------
 -- End Dictionaries                                                           --
 --------------------------------------------------------------------------------

--- a/halon/src/lib/HA/Services/Empty.hs
+++ b/halon/src/lib/HA/Services/Empty.hs
@@ -1,0 +1,115 @@
+-- |
+-- Copyright : (C) 2014 Xyratex Technology Limited.
+-- License   : All rights reserved.
+--
+
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-unused-binds #-}
+
+module HA.Services.Empty
+  ( HA.Services.Empty.__remoteTable
+  , emptyConfigDict
+  , emptyConfigDict__static
+  , emptySDict
+  , emptySDict__static
+  ) where
+
+import HA.ResourceGraph
+import HA.Resources
+import HA.Service
+
+import Control.Applicative (pure)
+import Control.Distributed.Process.Closure
+  ( SerializableDict(..)
+  , mkStatic
+  , remotable
+  )
+
+emptyConfigDict :: Dict (Configuration ())
+emptyConfigDict = Dict
+
+emptySDict :: SerializableDict ()
+emptySDict = SerializableDict
+
+--TODO Can we auto-gen this whole section?
+resourceDictServiceEmpty :: Dict (Resource (Service ()))
+resourceDictServiceProcessEmpty :: Dict (Resource (ServiceProcess ()))
+resourceDictConfigItemEmpty :: Dict (Resource ())
+resourceDictServiceEmpty = Dict
+resourceDictServiceProcessEmpty = Dict
+resourceDictConfigItemEmpty = Dict
+
+relationDictSupportsClusterServiceEmpty :: Dict (
+    Relation Supports Cluster (Service ())
+  )
+relationDictRunsNodeServiceProcessEmpty :: Dict (
+    Relation Runs Node (ServiceProcess ())
+  )
+relationDictWantsServiceProcessEmptyConfigItemEmpty :: Dict (
+    Relation WantsConf (ServiceProcess ()) ()
+  )
+relationDictHasServiceProcessEmptyConfigItemEmpty :: Dict (
+    Relation HasConf (ServiceProcess ()) ()
+  )
+relationDictInstanceOfServiceEmptyServiceProcessEmpty :: Dict (
+    Relation InstanceOf (Service ()) (ServiceProcess ())
+  )
+relationDictOwnsServiceProcessEmptyServiceName :: Dict (
+    Relation Owns (ServiceProcess ()) ServiceName
+  )
+
+relationDictSupportsClusterServiceEmpty = Dict
+relationDictRunsNodeServiceProcessEmpty = Dict
+relationDictWantsServiceProcessEmptyConfigItemEmpty = Dict
+relationDictHasServiceProcessEmptyConfigItemEmpty = Dict
+relationDictInstanceOfServiceEmptyServiceProcessEmpty = Dict
+relationDictOwnsServiceProcessEmptyServiceName = Dict
+
+remotable
+  [ 'emptyConfigDict
+  , 'emptySDict
+  , 'resourceDictServiceEmpty
+  , 'resourceDictServiceProcessEmpty
+  , 'resourceDictConfigItemEmpty
+  , 'relationDictSupportsClusterServiceEmpty
+  , 'relationDictRunsNodeServiceProcessEmpty
+  , 'relationDictHasServiceProcessEmptyConfigItemEmpty
+  , 'relationDictWantsServiceProcessEmptyConfigItemEmpty
+  , 'relationDictInstanceOfServiceEmptyServiceProcessEmpty
+  , 'relationDictOwnsServiceProcessEmptyServiceName
+  ]
+
+instance Resource (Service ()) where
+  resourceDict = $(mkStatic 'resourceDictServiceEmpty)
+
+instance Resource (ServiceProcess ()) where
+  resourceDict = $(mkStatic 'resourceDictServiceProcessEmpty)
+
+instance Resource () where
+  resourceDict = $(mkStatic 'resourceDictConfigItemEmpty)
+
+instance Relation Supports Cluster (Service ()) where
+  relationDict = $(mkStatic 'relationDictSupportsClusterServiceEmpty)
+
+instance Relation Runs Node (ServiceProcess ()) where
+  relationDict = $(mkStatic 'relationDictRunsNodeServiceProcessEmpty)
+
+instance Relation HasConf (ServiceProcess ()) () where
+  relationDict = $(mkStatic 'relationDictHasServiceProcessEmptyConfigItemEmpty)
+
+instance Relation WantsConf (ServiceProcess ()) () where
+  relationDict = $(mkStatic 'relationDictWantsServiceProcessEmptyConfigItemEmpty)
+
+instance Relation InstanceOf (Service ()) (ServiceProcess ()) where
+  relationDict = $(mkStatic 'relationDictInstanceOfServiceEmptyServiceProcessEmpty)
+
+instance Relation Owns (ServiceProcess ()) ServiceName where
+  relationDict = $(mkStatic 'relationDictOwnsServiceProcessEmptyServiceName)
+
+instance Configuration () where
+  schema = pure ()
+  sDict = $(mkStatic 'emptySDict)

--- a/halon/src/lib/HA/Services/OCF.hs
+++ b/halon/src/lib/HA/Services/OCF.hs
@@ -13,6 +13,7 @@ module HA.Services.OCF
     , HA.Services.OCF.__remoteTableDecl ) where
 
 import HA.Service
+import HA.Services.Empty
 import HA.Resources
 import HA.NodeAgent
 
@@ -43,7 +44,7 @@ remotableDecl [ [d|
     -- | Pacemaker / RH Cluster Suite SysV init-like service script.
     ocfProcess :: FilePath -> () -> Process ()
     ocfProcess script () = do
-        mbpid <- whereis (serviceName nodeAgent)
+        mbpid <- whereis (snString . serviceName $ nodeAgent)
         let na = maybe (error "NodeAgent is not registered.") id mbpid
         checkExitCode (liftIO $ System.rawSystem script ["start"])
                       go

--- a/mero-halon/src/halonctl/Handler/Service.hs
+++ b/mero-halon/src/halonctl/Handler/Service.hs
@@ -111,12 +111,12 @@ mkStandardServiceCmd svc = let
                     <$> tsNodes
                     <*> mkParser schema)
                   "Reconfigure the service on a node.")
-  in O.command (serviceName svc) (O.withDesc
+  in O.command (snString . serviceName $ svc) (O.withDesc
       ( O.subparser
       $  startCmd
       <> reconfCmd
       )
-      ("Control the " ++ (serviceName svc) ++ " service."))
+      ("Control the " ++ (snString . serviceName $ svc) ++ " service."))
 
 -- | Parse the options for the "service" command.
 parseService :: O.Parser ServiceCmdOptions

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Startup.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Startup.hs
@@ -32,7 +32,6 @@ import Control.Distributed.Process.Closure
     ( remotable, remotableDecl, mkStatic, mkClosure, functionTDict )
 import Control.Distributed.Process.Serializable ( SerializableDict(..) )
 import Data.Maybe ( catMaybes, isJust )
-import qualified Mero.Genders
 
 import Data.IORef ( newIORef, writeIORef, readIORef, IORef )
 import Data.List ( partition )

--- a/mero-halon/src/lib/HA/Services/Mero.hs
+++ b/mero-halon/src/lib/HA/Services/Mero.hs
@@ -13,6 +13,7 @@ import HA.NodeAgent
 import HA.EventQueue.Producer (promulgate)
 import HA.Resources
 import HA.Service
+import HA.Services.Empty
 import qualified Mero.Notification
 import Control.Distributed.Process.Closure
   (
@@ -92,7 +93,7 @@ remotableDecl [ [d|
             exists <- liftIO $ doesFileExist dummyFile
             when exists $ do
               liftIO $ removeFile dummyFile
-              mbpid <- whereis (serviceName nodeAgent)
+              mbpid <- whereis (snString . serviceName $ nodeAgent)
               case mbpid of
                 Nothing -> error "NodeAgent is not registered."
                 Just na -> promulgate (StripingError (Node (processNodeId na)))
@@ -113,7 +114,7 @@ remotableDecl [ [d|
 
         go epoch = do
             let shutdownAndTellThem = do
-                  mbpid <- whereis (serviceName nodeAgent)
+                  mbpid <- whereis (snString . serviceName $ nodeAgent)
                   case mbpid of
                       Nothing -> error "NodeAgent is not registered."
                       Just na -> expire . encodeP $ ServiceFailed (Node (processNodeId na)) m0d -- XXX

--- a/mero-halon/src/lib/Mero/RemoteTables.hs
+++ b/mero-halon/src/lib/Mero/RemoteTables.hs
@@ -11,7 +11,6 @@ import HA.Resources.Mero ( __remoteTable )
 #endif
 
 import HA.Services.Mero ( __remoteTableDecl )
-import HA.RecoveryCoordinator.Mero ( __remoteTable )
 import HA.RecoveryCoordinator.Mero.Startup ( __remoteTable, __remoteTableDecl )
 import Control.Distributed.Process (RemoteTable)
 
@@ -21,7 +20,6 @@ meroRemoteTable next =
    HA.Resources.Mero.__remoteTable $
 #endif
    HA.Services.Mero.__remoteTableDecl $
-   HA.RecoveryCoordinator.Mero.__remoteTable $
    HA.RecoveryCoordinator.Mero.Startup.__remoteTable $
    HA.RecoveryCoordinator.Mero.Startup.__remoteTableDecl $
    next


### PR DESCRIPTION
*Created by: nc6*

A service is now represented by its ProcessId. This is another step
towards removing the NodeAgent, since we have a central repository
to use in place of the node-local registry.

Note that this patch does not attempt to simplify the message types
(and remove ProcessEncode where possible); we leave this to a subsequent
patch.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tweag/halon/116)

<!-- Reviewable:end -->
