### PR TITLE
all depclean rm commands should have -f so that they do not fail if the ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ $(CLEAN):
 clean: $(CLEAN)
 depclean:
 	rm -rf .cabal-sandbox
-	rm cabal.sandbox.config
+	rm -f cabal.sandbox.config
 
 .PHONY: dep
 dep: cabal.sandbox.config


### PR DESCRIPTION
*Created by: benclifford*

...file does not exist

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tweag/halon/169)

<!-- Reviewable:end -->
