### PR TITLE
Get log files out of docker build container.

### DIFF
--- a/docker/3-halon/Dockerfile.in
+++ b/docker/3-halon/Dockerfile.in
@@ -12,5 +12,4 @@ RUN git checkout @@COMMIT@@
 # hopefully.
 
 ENV CABAL_FLAGS --flag="maintainer"
-RUN make
-
+# RUN docker/3-halon/build-with-artifacts

--- a/docker/3-halon/build-template
+++ b/docker/3-halon/build-template
@@ -11,4 +11,20 @@ echo COMMIT = $COMMIT
 cat docker/3-halon/Dockerfile.in \
   | sed "s/@@DEPVERSION@@/${DEPVERSION}/g" \
   | sed "s/@@COMMIT@@/${COMMIT}/g" > docker/3-halon/Dockerfile
-docker build -t tweag/halon docker/3-halon/
+
+docker build -t tweag/halon docker/3-halon/ || exit 1
+
+echo Running build container
+
+ContainerID=$(docker run -d --name=halon-build tweag/halon docker/3-halon/build-with-artifacts)
+
+docker attach $ContainerID
+
+BuildRC=$(docker wait $ContainerID)
+
+echo Build exit code $BuildRC
+
+echo "Copying log files from halon build container to CIRCLE_ARTIFACTS ( = ${CIRCLE_ARTIFACTS} )"
+docker cp halon-build:/halon/artifacts ${CIRCLE_ARTIFACTS}
+
+exit $BuildRC

--- a/docker/3-halon/build-with-artifacts
+++ b/docker/3-halon/build-with-artifacts
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+make
+RC=$?
+# save the exit code in $RC so that
+# we can exit with the same code
+# after extracting any log files.
+
+
+mkdir artifacts
+find . -name test_output | while read dir ; do \
+  target=/halon/artifacts/$(echo $dir | cut --delimiter="/" --fields=2); \
+  mkdir $target; \
+  cp -av $dir $target ; \
+done
+exit $RC
+


### PR DESCRIPTION
*Created by: benclifford*

This changes the way the main build step happens;
instead of using "docker build" to build everything,
lower level docker commands are run which allow
greater access to the build container (allowing file
system access, and allowing access to the container
even in the case that the build failed).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tweag/halon/170)

<!-- Reviewable:end -->
