### PR TITLE
Dev/promulgate

### DIFF
--- a/halon/src/lib/HA/EventQueue/Producer.hs
+++ b/halon/src/lib/HA/EventQueue/Producer.hs
@@ -22,12 +22,9 @@ import qualified HA.Services.EQTracker as EQT
 import Control.Distributed.Process
   ( Process
   , ProcessId
-  , ProcessMonitorNotification
   , NodeId
   , die
-  , expect
   , expectTimeout
-  , monitor
   , nsend
   , getSelfPid
   , say
@@ -120,7 +117,7 @@ promulgateHAEventPref peqnids eqnids evt = do
 -- | Add an event to the event queue, and don't die yet. This uses the local
 --   event tracker to identify the list of EQ nodes.
 -- FIXME: Use a well-defined timeout.
-promulgate :: Serializable a => a -> Process ()
+promulgate :: Serializable a => a -> Process ProcessId
 promulgate x = do
     self <- getSelfPid
     nsend EQT.name $ EQT.ReplicaRequest self
@@ -130,9 +127,7 @@ promulgate x = do
         pid <- case pref of
           [] -> promulgateEQ rest x
           _ -> promulgateEQPref pref rest x
-        _ <- monitor pid
-        (_ :: ProcessMonitorNotification) <- expect
-        return ()
+        return pid
       Nothing -> promulgate x
 {-
 The issue that this loop addresses in particular is if the node agent

--- a/halon/tests/HA/EventQueue/Tests.hs
+++ b/halon/tests/HA/EventQueue/Tests.hs
@@ -62,7 +62,9 @@ remoteRC controller = do
 remotable [ 'eqSDict, 'setRC, 'remoteRC ]
 
 triggerEvent :: Int -> Process ()
-triggerEvent = promulgate
+triggerEvent x = promulgate x >>= \pid -> withMonitor pid wait
+  where
+    wait = void (expect :: Process ProcessMonitorNotification)
 
 invoke :: Serializable a => ProcessId -> a -> Process ()
 invoke them x = send them x >> expect

--- a/mero-halon/src/lib/HA/Services/Mero.hs
+++ b/mero-halon/src/lib/HA/Services/Mero.hs
@@ -93,7 +93,7 @@ remotableDecl [ [d|
             exists <- liftIO $ doesFileExist dummyFile
             when exists $ do
               liftIO $ removeFile dummyFile
-              promulgate (StripingError (Node node))
+              void $ promulgate (StripingError (Node node))
 
         m0ctlMonitor srv out h_m0ctl = loop [] where
           loop buf = do

--- a/mero-halon/src/lib/HA/Services/SSPL.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL.hs
@@ -395,7 +395,7 @@ startActuators chan ac pid = do
   where
     informRC sp chans = do
       mypid <- getSelfPid
-      promulgate $ DeclareChannels mypid sp chans
+      _ <- promulgate $ DeclareChannels mypid sp chans
       msg <- expectTimeout (fromDefault . acDeclareChanTimeout $ ac)
       case msg of
         Nothing -> informRC sp chans


### PR DESCRIPTION
*Created by: nc6*

Just a 'cleaning' change - promulgate was currently blocking until the sending process died. This was less general than it could be, and `promulgateEQ` behaved differently. This PR changes `promulgate` to return the PID, which leaves it more general and matches `promulgateEQ`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tweag/halon/184)

<!-- Reviewable:end -->
