### PR TITLE
Introduce HALON_CABAL_FLAGS makefile option.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,17 +87,17 @@ libdirs=$(MERO_ROOT)/mero/.libs
 
 HLD_SEARCH_PATH=$(foreach dir,$(libdirs),--extra-lib-dirs=$(dir))
 
-override CABAL_FLAGS += --extra-include-dirs=$(MERO_ROOT) $(HLD_SEARCH_PATH) --extra-include-dirs=$(RPCLITE_PREFIX)
+override HALON_CABAL_FLAGS += --extra-include-dirs=$(MERO_ROOT) $(HLD_SEARCH_PATH) --extra-include-dirs=$(RPCLITE_PREFIX)
 endif
 
 ifdef USE_MERO
-override CABAL_FLAGS += -fmero
+override HALON_CABAL_FLAGS += -fmero
 endif
 
 ifdef USE_RPC
 TEST_NID = $(shell sudo lctl list_nids | head -1)
 TEST_LISTEN = $(TEST_NID):12345:34:1
-override CABAL_FLAGS += -frpc
+override HALON_CABAL_FLAGS += -frpc
 DC_HOST_IP = $(TEST_NID):12345:34
 else
 USE_TCP = 1
@@ -106,7 +106,7 @@ DC_HOST_IP = 127.0.0.1
 endif
 
 ifdef DEBUG
-override CABAL_FLAGS += -fdebug
+override HALON_CABAL_FLAGS += -fdebug
 endif
 
 ifdef USE_RPC
@@ -114,7 +114,7 @@ ifdef USE_RPC
 # explicitly because most operating systems reset that environment
 # variable for setuid binaries.
 SUDO = sudo -E LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)
-override CABAL_FLAGS += --extra-include-dirs=$(MERO_ROOT) --extra-lib-dirs=$(MERO_ROOT)/mero/.libs
+override HALON_CABAL_FLAGS += --extra-include-dirs=$(MERO_ROOT) --extra-lib-dirs=$(MERO_ROOT)/mero/.libs
 else
 SUDO =
 endif
@@ -126,7 +126,7 @@ export GENDERS
 
 ifndef NO_TESTS
 CABAL_BUILD_JOBS = --jobs=1
-override CABAL_FLAGS += --run-tests
+override HALON_CABAL_FLAGS += --run-tests
 endif
 
 export USE_TCP


### PR DESCRIPTION
*Created by: qnikst*

Make CABAL_FLAGS be applicable to all cabal invocations, and
HALON_CABAL_FLAGS for halon related packages. This allow setting
ghc buy running:

```
CABAL_FLAGS="--with-compiler=ghc-7.8.3" make
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tweag/halon/188)

<!-- Reviewable:end -->
