### PR TITLE
Add host and drive information to the graph

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -81,6 +81,7 @@ Library
                    HA.RecoveryCoordinator.Mero
                    HA.RecoveryCoordinator.CEP
                    HA.RecoveryCoordinator.Definitions
+                   HA.Resources.Mero
   Build-Depends:   base,
                    aeson,
                    amqp,
@@ -94,6 +95,7 @@ Library
                    mtl,
                    options-schema,
                    process,
+                   scientific,
                    sspl,
                    text,
                    binary,
@@ -108,7 +110,7 @@ Library
                  hastate/hastate_foms.c
       include-dirs: hastate
   if flag(mero) || flag(mero-note)
-      Exposed-Modules: HA.Resources.Mero
+      Exposed-Modules: HA.Resources.Mero.Note
       cc-options: -Wno-attributes -Werror -g -DM0_INTERNAL= -DM0_EXTERN=extern
       extra-libraries: mero
       Build-Depends: rpclite,
@@ -392,6 +394,7 @@ Test-Suite unit-tests
                     options-schema,
                     hashable,
                     unordered-containers,
+                    sspl,
                     tasty,
                     tasty-hunit,
                     tasty-files
@@ -439,6 +442,7 @@ Test-Suite integration-tests
                     options-schema,
                     hashable,
                     unordered-containers,
+                    sspl,
                     tasty,
                     tasty-hunit,
                     tasty-files

--- a/mero-halon/src/lib/HA/Resources/Mero/Note.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero/Note.hs
@@ -1,0 +1,95 @@
+-- |
+-- Copyright : (C) 2015 Seagate Technology Limited.
+-- License   : All rights reserved.
+--
+-- Mero notification specific resources.
+
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE MagicHash                  #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
+
+module HA.Resources.Mero.Note where
+
+import HA.Resources
+import HA.Resources.Mero
+import HA.ResourceGraph
+  ( Resource(..)
+  , Relation(..)
+  , Dict(..)
+  )
+import Control.Distributed.Process.Closure
+
+import Mero.ConfC (Fid(..))
+
+import Data.Hashable (Hashable)
+import Data.Binary (Binary)
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+
+--------------------------------------------------------------------------------
+-- Resources                                                                  --
+--------------------------------------------------------------------------------
+
+newtype ConfObject = ConfObject
+    { confObjectId   :: Fid
+    } deriving (Eq, Show, Generic, Typeable)
+
+instance Binary ConfObject
+instance Hashable ConfObject
+
+-- | Configuration object states. See "Requirements: Mero failure notification"
+-- document for the semantics of each state.
+data ConfObjectState
+    = M0_NC_UNKNOWN
+    | M0_NC_ACTIVE
+    | M0_NC_FAILED
+    | M0_NC_TRANSIENT
+    | M0_NC_DEGRADED
+    | M0_NC_RECOVERING
+    | M0_NC_OFFLINE
+    | M0_NC_ANATHEMISED
+    deriving (Eq, Enum, Typeable, Generic)
+
+instance Binary ConfObjectState
+instance Hashable ConfObjectState
+
+--------------------------------------------------------------------------------
+-- Dictionaries                                                               --
+--------------------------------------------------------------------------------
+
+-- XXX Only nodes and services have runtime information attached to them, for now.
+
+resdict_ConfObject :: Dict (Resource ConfObject)
+resdict_ConfObjectState :: Dict (Resource ConfObjectState)
+
+resdict_ConfObject = Dict
+resdict_ConfObjectState = Dict
+
+reldict_At_ConfObject_Node :: Dict (Relation At ConfObject Node)
+reldict_Is_ConfObject_ConfObjectState :: Dict (Relation Is ConfObject ConfObjectState)
+
+reldict_At_ConfObject_Node = Dict
+reldict_Is_ConfObject_ConfObjectState = Dict
+
+
+remotable [ 'resdict_ConfObject
+          , 'resdict_ConfObjectState
+          , 'reldict_At_ConfObject_Node
+          , 'reldict_Is_ConfObject_ConfObjectState
+          ]
+
+instance Resource ConfObject where
+    resourceDict = $(mkStatic 'resdict_ConfObject)
+
+instance Resource ConfObjectState where
+    resourceDict = $(mkStatic 'resdict_ConfObjectState)
+
+instance Relation At ConfObject Node where
+    relationDict = $(mkStatic 'reldict_At_ConfObject_Node)
+
+instance Relation Is ConfObject ConfObjectState where
+    relationDict = $(mkStatic 'reldict_Is_ConfObject_ConfObjectState)

--- a/mero-halon/src/lib/Mero/RemoteTables.hs
+++ b/mero-halon/src/lib/Mero/RemoteTables.hs
@@ -6,8 +6,9 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 module Mero.RemoteTables (meroRemoteTable) where
 
-#ifdef USE_MERO
 import HA.Resources.Mero ( __remoteTable )
+#ifdef USE_MERO_NOTE
+import HA.Resources.Mero.Note ( __remoteTable )
 #endif
 
 import HA.Services.Mero ( __remoteTableDecl )
@@ -18,8 +19,9 @@ import Control.Distributed.Process (RemoteTable)
 
 meroRemoteTable :: RemoteTable -> RemoteTable
 meroRemoteTable next =
-#ifdef USE_MERO
    HA.Resources.Mero.__remoteTable $
+#ifdef USE_MERO_NOTE
+   HA.Resources.Mero.Note.__remoteTable $
 #endif
    HA.Services.Mero.__remoteTableDecl $
    HA.Services.SSPL.__remoteTable $

--- a/mero-halon/tests/test.hs
+++ b/mero-halon/tests/test.hs
@@ -44,6 +44,10 @@ ut transport = return $
     testGroup "ut"
       [ testCase "RCServiceRestarting" $
           HA.RecoveryCoordinator.Mero.Tests.testServiceRestarting transport
+      , testCase "RGHostResources" $
+          HA.RecoveryCoordinator.Mero.Tests.testHostAddition transport
+      , testCase "RGDriveResources" $
+          HA.RecoveryCoordinator.Mero.Tests.testDriveAddition transport
       , testCase "uncleanRPCClose" $ threadDelay 2000000
       ]
 


### PR DESCRIPTION
*Created by: nc6*

This PR addresses three Asana tasks:
https://app.asana.com/0/12314345447678/28254980877669
https://app.asana.com/0/12314345447678/28254980877663
... and another that I can't find right now. Maybe we forgot to create it.

Either way, this adds Drives, Hosts, Enclosures and Interfaces to the resource graph, and updates them in response to host/drive update messages from SSPL. The rules governing this are fairly simple at the moment, since this PR is solely intended to get this information into the graph.

There are two tests that verify information is added to the graph correctly.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tweag/halon/189)

<!-- Reviewable:end -->
