### PR TITLE
substitute out characters that are legal in branch names but illegal in ...

### DIFF
--- a/docker/functions.sh
+++ b/docker/functions.sh
@@ -9,7 +9,7 @@ DOCKERDIR=$3
 
 TAG=${BASE}:${HASH}
 
-BRANCH=$(git symbolic-ref --short HEAD)
+BRANCH=$(git symbolic-ref --short HEAD | sed 's/[^0-9a-zA-Z_\-]/_/g')
 LATESTTAG=${BASE}:$BRANCH
 
 docker pull $TAG


### PR DESCRIPTION
*Created by: qnikst*

...docker tags

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tweag/halon/208)

<!-- Reviewable:end -->
