### PR TITLE
Implement halonctl `stop` command

### DIFF
--- a/halon/src/lib/HA/NodeAgent/Messages.hs
+++ b/halon/src/lib/HA/NodeAgent/Messages.hs
@@ -34,8 +34,10 @@ data ServiceMessage =
 instance Binary ServiceMessage
 
 -- FIXME: Do we want to keep this just for the dummy service?
+-- FIXME: No we don't. We now use it in RC
 data ExitReason = Shutdown
                 | Reconfigure
+                | UserStop
                 deriving (Eq, Show, Generic, Typeable)
 
 instance Binary ExitReason

--- a/mero-halon/src/halonctl/Main.hs
+++ b/mero-halon/src/halonctl/Main.hs
@@ -68,5 +68,5 @@ run (Options { .. }) = do
     liftIO $ printHeader
     case optCommand of
       Bootstrap bs -> bootstrap rnids bs
-      Service bs -> service rnids bs
+      Service bs   -> service rnids bs
   return ()

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/CEP.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/CEP.hs
@@ -120,6 +120,12 @@ rcRules argv eq = do
         i <- getNoisyPingCount
         liftProcess $ sayRC $ "Noisy ping count: " ++ show i
 
+    defineHAEvent "stop-request" id $ \(HAEvent _ msg _) -> do
+        ServiceStopRequest node svc <- decodeMsg msg
+        res                         <- lookupRunningService node svc
+        for_ res $ \sp ->
+          killService sp UserStop
+
     onEveryHAEvent $ \(HAEvent eid _ _) s -> do
         usend eq eid
         return s

--- a/mero-halon/tests/test.hs
+++ b/mero-halon/tests/test.hs
@@ -56,6 +56,8 @@ ut transport = return $
       , testCase "uncleanRPCClose" $ threadDelay 2000000
       , testCase "RCDecisionLogOutput" $
         HA.RecoveryCoordinator.Mero.Tests.testDecisionLog transport
+      , testCase "RCServiceStopped" $
+        HA.RecoveryCoordinator.Mero.Tests.testServiceStopped transport
       ]
 
 runTests :: (Transport -> IO TestTree) -> IO ()


### PR DESCRIPTION
*Created by: YoEight*

Not intented to be merged but much easier for discussion.

On my way to implement `stop` command for `halonctl`. I forgot something precious I will lack of.

At some point, in order to kill a service process, I need to look it up from from the replicated graph. Problem is, I have no type at this level and we need to a type that implements `Configuration` in order to traverse the graph. Any suggestion ?
