### PR TITLE
replicated-log: prevent query storms and advertise configuration to old replicas.

### DIFF
--- a/replicated-log/src/Control/Distributed/Log/Internal.hs
+++ b/replicated-log/src/Control/Distributed/Log/Internal.hs
@@ -771,6 +771,11 @@ replica Dict
                        \_ -> do
                   -- We must already know this decree, or this decree is from an
                   -- old legislature, so skip it.
+
+                  -- Advertise our configuration to other replicas if we are
+                  -- getting old decrees.
+                  forM_ others $ \ρ ->
+                    sendReplica logName ρ $ Max self legD d epoch ρs
                   go st
 
               -- Commit the decree to the log.


### PR DESCRIPTION
*Created by: facundominguez*

A fix for
https://app.asana.com/0/12314345447678/17133500082204
and a partial fix for
https://app.asana.com/0/12314345447678/32129747604066
