### PR TITLE
Allow halonctl to query the location of the tracking station.

### DIFF
--- a/mero-halon/scripts/simplecluster.sh
+++ b/mero-halon/scripts/simplecluster.sh
@@ -14,5 +14,5 @@ $HALOND -l $SAT > /tmp/satellite.log 2>&1 &
 $HALONCTL -a $TS bootstrap station
 $HALONCTL -a $SAT bootstrap satellite -t $TS
 
-$HALONCTL -a $SAT service decision-log start -t $TS -f /tmp/decision.log
-$HALONCTL -a $SAT service frontier start -t $TS -p 9028
+$HALONCTL -a $SAT service decision-log start -f /tmp/decision.log --eqt-timeout 0
+$HALONCTL -a $SAT service frontier start -p 9028 --eqt-timeout 0


### PR DESCRIPTION
*Created by: nc6*

- Halonctl now queries the location of the tracking station from
  the satellite nodes it is asked to control. An error is shown to
  the user if this fails.
- It is still possible to manually specify the location of TS nodes.
  This is possibly the better solution in tests, because it eliminates
  race conditions with the EQT.
- Adjust the 'simplecluster' script to take advantage of this. A small
  sleep is required to combat the above race condition.
