### PR TITLE
replicated-log: recovery

### DIFF
--- a/consensus-paxos/src/Control/Distributed/Process/Consensus/Paxos.hs
+++ b/consensus-paxos/src/Control/Distributed/Process/Consensus/Paxos.hs
@@ -6,7 +6,9 @@
 -- one or any optimizations thereof.
 
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE KindSignatures #-}
 
@@ -27,9 +29,12 @@ import Control.Distributed.Process.Serializable
 
 import Data.Binary (Binary, encode, decode)
 import Data.ByteString.Lazy (ByteString)
+import Data.Map (Map)
+import qualified Data.Map as Map
 import Data.Typeable
 import Control.Monad
 
+import Data.Maybe (isJust)
 import Data.List (maximumBy)
 import Data.Function (on)
 import GHC.Generics (Generic)
@@ -77,11 +82,11 @@ import GHC.Generics (Generic)
 
 -- | Choose the value @x@ of any vote pertaining to the given decree number in
 -- the highest ballot.
-chooseValue :: DecreeId -> a -> [Msg.Ack a] -> a
-chooseValue d def acks =
+chooseValue :: DecreeId -> [Msg.Ack a] -> Maybe a
+chooseValue d acks =
     if null acks'
-    then def
-    else Msg.value $ maximumBy (compare `on` Msg.ballot) acks'
+    then Nothing
+    else Just $ Msg.value $ maximumBy (compare `on` Msg.ballot) acks'
   where
     acks' = filter ((d ==) . Msg.decree) acks
 
@@ -92,23 +97,25 @@ inline chooseValue(p_x1,p_d,p_x,p_acks) {
 }
 *-}
 
-type Trimmed = Bool
-
 -- | A persistent store for acceptor state
 data AcceptorStore = AcceptorStore
-    { -- | Inserts a decree in the store.
-      storeInsert :: DecreeId -> ByteString -> IO ()
+    { -- | Inserts decrees in the store.
+      storeInsert :: [(DecreeId, ByteString)] -> IO ()
       -- | Retrieves a decree in the store.
       --
       -- If the value was trimmed, it yields @Left True@.
       -- If the value was never stored, it yields @Left False@.
-    , storeLookup :: DecreeId -> IO (Either Trimmed ByteString)
+    , storeLookup :: DecreeId -> IO (Maybe ByteString)
       -- | Saves a value in the store.
     , storePut :: ByteString -> IO ()
       -- | Restores a value from the store.
     , storeGet :: IO (Maybe ByteString)
       -- | Trims state below the given decree.
     , storeTrim :: DecreeId -> IO ()
+      -- | Lists the stored decrees.
+    , storeList :: IO [(DecreeId, ByteString)]
+      -- | Yields a map of the stored decrees.
+    , storeMap :: IO (Map DecreeId ByteString)
       -- | Closes the store.
     , storeClose :: IO ()
     }
@@ -134,64 +141,153 @@ paxosTrace _ = return ()
 --
 --   * P1. An acceptor can accept a proposal in ballot b iff it has not
 --   responded to a 'Prepare' request in a ballot greater than b.
-acceptor :: forall a n. Serializable a
-         => a -> (n -> IO AcceptorStore) -> n -> Process ()
-acceptor _ config name = flip finally (paxosTrace "Acceptor terminated") $
+acceptor :: forall a n. (Serializable a, Serializable n)
+         => (forall b. Serializable b => n -> b -> Process ())
+         -> a -> DecreeId -> (n -> IO AcceptorStore) -> n -> Process ()
+acceptor sendA _ startDecree0 config name =
+  flip finally (paxosTrace "Acceptor terminated") $
   bracket (liftIO $ config name) (liftIO . storeClose) $ \case
   AcceptorStore {..} -> do
-       liftIO storeGet >>= loop . maybe Bottom (Value . decode)
+       liftIO storeGet >>= loop startDecree0 . maybe Bottom (Value . decode)
     where
-      loop :: Lifted BallotId -> Process b
-      loop b = do
-          self <- getSelfPid
+      loop :: DecreeId -> Lifted BallotId -> Process b
+      loop sd b = do
           paxosTrace "Acceptor waiting"
           receiveWait
-              [ match $ \(Msg.Prepare d b' λ) -> do
-                  paxosTrace "Acceptor prepare"
-                  if b <= Value b'
+              [ match $ \(Msg.Prepare d b' λ) ->
+                  -- Don't reply if the value was trimmed.
+                  -- The upper layers will have to figure out how
+                  -- to get the trimmed values otherwise.
+                  if (d < sd) then do
+                    paxosTrace $ "Prepare: Trimmed " ++ show (d, b', λ)
+                    loop sd b
+                  else if b <= Value b'
                   then do
-                      when (b < Value b') $
-                        liftIO $ storePut $ encode b'
-                      ebs <- liftIO $ storeLookup d
-                      case ebs of
-                        Left True ->
-                          -- Don't reply if the value was trimmed.
-                          -- The upper layers will have to figure out how
-                          -- to get the trimmed values otherwise.
-                          paxosTrace $ "Prepare: Trimmed " ++ show (d, b', λ)
-                        Left False -> do
-                          paxosTrace $ "Prepare: Promise new " ++
-                                       show (d, b', λ)
-                          usend λ $ Msg.Promise b' self ([] :: [Msg.Ack a])
-                        Right bs -> do
-                          let (b'', x) = decode bs
-                          paxosTrace $ "Prepare: Promise " ++ show (d, b', λ)
-                          usend λ $ Msg.Promise b' self
-                                                [Msg.Ack d b'' self (x :: a)]
-                      loop (Value b')
+                    self <- getSelfPid
+                    mbs <- liftIO (storeLookup d)
+                    let acks Nothing = []
+                        acks (Just bs) = let (b'', x) = decode bs
+                                          in [Msg.Ack d b'' (x :: a)]
+                    paxosTrace $ "Prepare: Promise " ++
+                                 show (isJust mbs, d, b', λ)
+                    usend λ $ Msg.Promise b' self $ acks mbs
+                    loop sd (Value b')
                   else do
-                      paxosTrace $ "Prepare: Nack " ++
-                                   show (d, b', λ, fromValue b)
-                      usend λ $ Msg.Nack $ fromValue b
-                      loop b
-              , match $ \(Msg.Syn d b' λ x) -> do
-                  paxosTrace "Acceptor Syn"
-                  if b <= Value b'
+                    paxosTrace $ "Prepare: Nack " ++
+                                 show (d, b', λ, fromValue b)
+                    usend λ $ Msg.Nack $ fromValue b
+                    loop sd b
+              , match $ \(Msg.Syn d b' λ x) ->
+                  -- Don't reply if the value was trimmed.
+                  -- The upper layers will have to figure out how
+                  -- to get the trimmed values otherwise.
+                  if (d < sd) then loop sd b
+                  else if b <= Value b'
                   then do
-                      when (b < Value b') $
-                        liftIO $ storePut $ encode b'
-                      liftIO $ storeInsert d $ encode (b', x :: a)
-                      paxosTrace $ "Syn: Ack " ++ show (d, b', λ)
-                      usend λ $ Msg.Ack d b' self x
-                      loop (Value b')
+                    when (b < Value b') $
+                      liftIO $ storePut $ encode b'
+                    liftIO $ storeInsert [(d, encode (b', x :: a))]
+                    paxosTrace $ "Syn: Ack " ++ show (d, b', λ)
+                    usend λ $ Msg.Ack d b' x
+                    loop sd (Value b')
                   else do
-                      paxosTrace $ "Syn: Nack " ++ show (d, b', λ, fromValue b)
-                      usend λ $ Msg.Nack $ fromValue b
-                      loop b
+                    paxosTrace $ "Syn: Nack " ++ show (d, b', λ, fromValue b)
+                    usend λ $ Msg.Nack $ fromValue b
+                    loop sd b
               , match $ \(Trim d) -> do
                   liftIO $ storeTrim d
-                  loop b
+                  loop (max d sd) b
+
+                -- Synchronization handlers
+
+              , match $ \(Msg.SyncStart κ αs) -> do
+                  paxosTrace $ "SyncStart " ++ show κ
+                  -- Advertise the decrees we know about
+                  dvs <- liftIO storeList
+                  forM_ αs $ flip sendA $
+                    Msg.SyncAdvertise κ name
+                      (intervals $ map fst dvs)
+                  loop sd b
+
+              , match $ \(Msg.SyncAdvertise κ α ds) -> do
+                  paxosTrace $ "SyncAdvertise " ++ show (κ, ds)
+                  -- Request any missing decrees
+                  dvs <- liftIO storeList
+                  let rqs = diffIntervals ds $
+                              if initialDecreeId < sd then
+                                (initialDecreeId, sd) :
+                                  intervals (dropWhile (<sd) $ map fst dvs)
+                              else
+                                intervals (map fst dvs)
+                  if null rqs then do
+                    usend κ $ Msg.SyncCompleted name
+                  else
+                    sendA α $ Msg.SyncRequest κ name rqs
+                  loop sd b
+
+              , match $ \(Msg.SyncRequest κ α ds) -> do
+                  paxosTrace $ "SyncRequest " ++ show (κ, ds)
+                  -- Reply with the values for the missing decrees
+                  let lookupRanges _ [] = []
+                      lookupRanges m ((d0, d1) : dps) =
+                        let (_, mv0, m') = Map.splitLookup d0 m
+                            (mvs, m'') = Map.split d1 m'
+                        in maybe id (\v0 -> ((d0, v0):)) mv0 $
+                             Map.assocs mvs ++ lookupRanges m'' dps
+                  m <- liftIO storeMap
+                  sendA α $ Msg.SyncResponse κ $ lookupRanges m ds
+                  loop sd b
+
+              , match $ \(Msg.SyncResponse κ dvs) -> do
+                  paxosTrace $ "SyncResponse " ++ show (κ, map fst dvs)
+                  liftIO $ storeInsert dvs
+                  usend κ $ Msg.SyncCompleted name
+                  loop sd b
+
+                -- querying decrees
+              , match $ \(Msg.QueryDecrees κ d) -> do
+                  paxosTrace $ "QueryDecrees " ++ show (κ, d)
+                  m <- liftIO storeMap
+                  let (_, mv, m') = Map.splitLookup d m
+                      acks = [ Msg.Ack di b' v
+                             | (di, bs) <- maybe id ((:) . (d,)) mv $
+                                             Map.assocs m'
+                             , let (b', v) = decode bs :: (BallotId, a)
+                             ]
+                  usend κ acks
+                  loop sd b
               ]
+
+-- > expand . intervals == intervals . expand == id
+-- >   where
+-- >     expand = concatMap (\(x, y) -> [x .. pred y])
+--
+-- forall x, y, u, v, w, xs: @sorted xs@ implies
+--
+-- > all (uncurry (<)) (intervals xs)
+-- > && [(u, v), (w, x)] `isInfixOf` intervals xs ==> v < w
+--
+intervals :: (Enum a, Eq a) => [a] -> [(a, a)]
+intervals (x0 : xs0) = go x0 (succ x0) xs0
+  where
+    -- invariant: @x < y@
+    -- invariant: @all (y<) xs@
+    -- invariant: @[x .. pred y] `isPrefixOf` head (go x y xs)@
+    go x y (z : xs) | y == z    = go x (succ z) xs
+                    | otherwise = (x, y) : go z (succ z) xs
+    go x y [] = [(x, y)]
+intervals  [] = []
+
+-- | @expand xs \\ expand ys == expand (diffIntervals xs ys)@
+diffIntervals :: Ord a => [(a, a)] -> [(a, a)] -> [(a, a)]
+diffIntervals xs [] = xs
+diffIntervals [] _ys = []
+diffIntervals ((x, x') : xss) ys@((y, y') : yss)
+  | x < y' && y < x' =
+    if x < y then (x, y) : diffIntervals xss ys
+    else if x' <= y' then diffIntervals xss ys
+         else diffIntervals ((y', x') : xss) yss
+  | otherwise = (x, x') : diffIntervals xss ys
 
 {-*promela
 

--- a/replicated-log/replicated-log.cabal
+++ b/replicated-log/replicated-log.cabal
@@ -90,6 +90,7 @@ Test-Suite tests
                     consensus-paxos,
                     constraints >= 0.4,
                     containers >= 0.5,
+                    directory >= 1.2.2,
                     distributed-process-scheduler,
                     distributed-process-test,
                     distributed-static >= 0.2.0,

--- a/replicated-log/src/Control/Distributed/Log.hs
+++ b/replicated-log/src/Control/Distributed/Log.hs
@@ -23,6 +23,7 @@ module Control.Distributed.Log
     , append
     , status
     , reconfigure
+    , recover
     , addReplica
     , killReplica
     , removeReplica

--- a/replicated-log/src/Control/Distributed/Log/Messages.hs
+++ b/replicated-log/src/Control/Distributed/Log/Messages.hs
@@ -36,7 +36,12 @@ data Helo =
          (Closure NominationPolicy)   -- Policy to decide new membership.
     deriving (Typeable, Generic)
 
+-- | @Recover sender newMembership@
+data Recover = Recover ProcessId [NodeId]
+  deriving (Typeable, Generic)
+
 instance Binary Helo
+instance Binary Recover
 
 --------------------------------------------------------------------------------
 -- Inter-replica messages                                                     --

--- a/replicated-log/tests/random.hs
+++ b/replicated-log/tests/random.hs
@@ -73,14 +73,14 @@ testConfig = Log.Config
                     mref <- newIORef Map.empty
                     vref <- newIORef Nothing
                     return AcceptorStore
-                      { storeInsert = \d v -> do
-                          modifyIORef mref $ Map.insert d v
-                      , storeLookup = \d -> do
-                          r <- readIORef mref
-                          return $ maybe (Left False) Right $ Map.lookup d r
+                      { storeInsert =
+                          modifyIORef mref . flip (foldr (uncurry Map.insert))
+                      , storeLookup = \d -> Map.lookup d <$> readIORef mref
                       , storePut = writeIORef vref . Just
                       , storeGet = readIORef vref
                       , storeTrim = const $ return ()
+                      , storeList = Map.assocs <$> readIORef mref
+                      , storeMap = readIORef mref
                       , storeClose = return ()
                       }
                  )

--- a/rfc/014-reconfiguration.md
+++ b/rfc/014-reconfiguration.md
@@ -97,8 +97,9 @@ least half of the replicas in the old membership take part in the new one. Here
 replicas of the old membership means a replica located anywhere and seeded with
 the state of a replica in the old membership.
 
-By asking all the acceptors in the new membership to be online, we can scan the
-acceptors for any accepted decrees and propagate them to a quorum of acceptors.
+By asking all acceptors and all replicas in the new membership to be online, we
+can scan the acceptors for any accepted decrees and propagate them to a quorum
+of acceptors.
 
 From then on it is safe to submit a reconfiguration request with the new
 membership.


### PR DESCRIPTION
*Created by: facundominguez*

Reconfiguration requests are dropped in the absence of quorum. Instead, the user should use `Log.recover` to get quorum again. See the included RFC.

This should allow to recover a group when no replica is so much delayed that no acceptor remembers the missing decrees. To recover when acceptors don't remember the missing decrees provisions need to be taken to keep replicas sufficiently in sync. Deferring that to treat it as another task.
