### PR TITLE
Suppress what looks like an error message if not autobooting.

### DIFF
--- a/halon/src/lib/HA/Startup.hs
+++ b/halon/src/lib/HA/Startup.hs
@@ -258,6 +258,8 @@ startupHalonNode lnid rcClosure = do
     _ <- forkIO $ Exception.catch (tryRunProcess lnid $ Storage.runStorage)
                                   (\e -> throwTo tid (e::SomeException))
 
-    Exception.catch (tryRunProcess lnid (autoboot rcClosure))
-                    (\(e :: SomeException) -> hPutStrLn stderr $ "Cannot autoboot: " ++ show e)
+    Exception.catch
+      (tryRunProcess lnid (autoboot rcClosure))
+      (\(_ :: SomeException) -> hPutStrLn stderr
+        $ "No persisted state could be read. Starting in listen mode.")
     tryRunProcess lnid $ eqTrackerProcess []


### PR DESCRIPTION
*Created by: nc6*

Not autobooting is perfectly fine for most nodes, but the message
made it look like an error. Instead, just print a friendly message.
