### PR TITLE
Remove tix and mix files during build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ CLEAN := $(patsubst %,%_clean,$(PACKAGES))
 $(CLEAN):
 	-cd $(patsubst %_clean, %, $@) && $(SUDO) cabal clean
 	-cabal sandbox hc-pkg -- unregister $(patsubst %_clean, %, $@) --force
-clean: $(CLEAN)
+clean: clean_tixmix $(CLEAN)
 depclean:
 	rm -rf .cabal-sandbox
 	rm -f cabal.sandbox.config


### PR DESCRIPTION
*Created by: qnikst*

This change removes .tix and .mix files during `make`.

@Fuuzetsu  you could be also interested in this PR
