### PR TITLE
Notify about accurate RC death reason.

### DIFF
--- a/halon/src/lib/HA/RecoverySupervisor.hs
+++ b/halon/src/lib/HA/RecoverySupervisor.hs
@@ -72,6 +72,7 @@ import Control.Distributed.Process.Closure ( remotable, mkClosure )
 import Control.Distributed.Process.Timeout ( retry, timeout )
 
 import Control.Concurrent ( newMVar, takeMVar, putMVar, readMVar, newEmptyMVar )
+import Control.Exception ( SomeException, throwIO )
 import Control.Monad ( when, void )
 import Data.Binary ( Binary )
 import Data.Int ( Int64 )
@@ -175,7 +176,9 @@ recoverySupervisor rg rcP = do
 
     spawnRC = do
       say "RS: I'm the new leader, so starting RC ..."
-      rc <- spawnLocal rcP
+      rc <- spawnLocal $ (rcP >> say "RS: RC died normally")
+                `catch` \e -> do say $ "RS: RC died " ++ show (e::SomeException)
+                                 liftIO $ throwIO e
       _ <- monitor rc
       return rc
 
@@ -207,8 +210,7 @@ recoverySupervisor rg rcP = do
        mn <- expectTimeout 0
        case mn of
          Just (ProcessMonitorNotification _ pid reason)
-           | pid == rc -> do say $ "RS: RC died: " ++ show reason
-                             return True
+           | pid == rc -> return True
            | otherwise -> rcHasDied rc
          Nothing -> return False
 


### PR DESCRIPTION
*Created by: qnikst*

This patch fixes a way how a message about RC death
reported, there are 2 major changes:
1. message report could not be blocked because of quorum loss;
2. normal death is also reported.
