### PR TITLE
Kill redundant processes in NodeUp.

### DIFF
--- a/halon/src/lib/HA/NodeUp.hs
+++ b/halon/src/lib/HA/NodeUp.hs
@@ -36,6 +36,7 @@ import Control.Distributed.Process
   , say
   , processNodeId
   , monitor
+  , kill
   , ProcessMonitorNotification(..)
   , receiveTimeout
   , matchIf
@@ -80,7 +81,7 @@ nodeUp (eqs, delay) = do
                 [ matchIf (\(ProcessMonitorNotification ref' _ _) -> ref' == ref)
                           (\_ -> return ()) ]
       case msg of
-        Nothing -> go pid
+        Nothing -> kill sender "starting new promulgate action" >> go pid
         Just _  -> expect
 
 remotable ['nodeUp]


### PR DESCRIPTION
*Created by: qnikst*

Current nodeUp implementation spawns new promulgate process
each "connect timeout" seconds. All of those processes will
not be stopped until they deliver message. As a result additional
amount of CPU and traffic usage appear.
