### PR TITLE
Run the halond from test-start-service-local inside temp dir

### DIFF
--- a/mero-halon/tests/Distributed/startService-local.hs
+++ b/mero-halon/tests/Distributed/startService-local.hs
@@ -47,7 +47,7 @@ import Network.Transport.TCP (createTransport, defaultTCPParameters)
 #endif
 
 import qualified Control.Exception as E (bracket, catch, SomeException)
-import System.Directory (setCurrentDirectory, createDirectoryIfMissing)
+import System.Directory (setCurrentDirectory, createDirectoryIfMissing, getTemporaryDirectory)
 import System.Environment
 import System.IO
 import System.FilePath ((</>), takeDirectory)
@@ -68,7 +68,8 @@ main =
     buildPath <- getBuildPath
     progName <- getProgName
 
-    let testDir = takeDirectory buildPath </> "test" </> progName
+    tmpDir <- getTemporaryDirectory
+    let testDir = tmpDir </> "test" </> progName
     createDirectoryIfMissing True testDir
 
 #ifdef USE_RPC


### PR DESCRIPTION
*Created by: Fuuzetsu*

There are only certain filesystems that mero trace files can be mmaped
from. For example, it does not work if the test is ran from a vboxfs
host mount. Instead of creating test artifacts inside the build
directory somewhere, we use a temporary directory. This should mean
that the test works more often.

Note that this does not mean the test doesn't need manual
intervention. The user still has to make sure the mero kernel modules
are started first. There is room for improvement in error reporting
from the tests.
