### PR TITLE
Avoid coping log files that were already stored.

### DIFF
--- a/docker/3-halon/build-with-artifacts
+++ b/docker/3-halon/build-with-artifacts
@@ -28,7 +28,7 @@ find . -name test_output | while read dir ; do \
   mkdir $target; \
   cp -av $dir $target ; \
 done
-find . -name \*.log -type f | while read l ; do \
+find . -type f -name \*.log \( -regex '.*/artifacts.*' -prune -o -print \) | while read l ; do \
   cp -v $l /halon/artifacts/logs/ ; \
 done
 
@@ -46,5 +46,16 @@ if [ "$RC" == "0" ] ; then
   RC=$?
   cp -vr coverage /halon/artifacts/
 fi
+
+cd /halon/artifacts
+find | while read l ; do \
+  n=$(echo $l | sed s/[^-a-zA-Z0-9/.]/_/g)
+  if [[ $n != $l ]] ; then
+    while test -f $n ; do
+      n=${n}_
+    done
+    mv -v "$l" "$n"
+  fi
+done
 
 exit $RC


### PR DESCRIPTION
*Created by: qnikst*

This change avoids CI errors like:

2015-09-02T08:32:04.817101346Z cp: ‘./artifacts/logs/consensus-paxos-0.1-tests.log’
  and ‘/halon/artifacts/logs/consensus-paxos-0.1-tests.log’ are the same file
