### PR TITLE
Synchronous startup

### DIFF
--- a/halon/src/lib/HA/Startup.hs
+++ b/halon/src/lib/HA/Startup.hs
@@ -263,7 +263,7 @@ remotableDecl [ [d|
 startupHalonNode :: Closure ([NodeId] -> ProcessId -> ProcessId -> Process ())
                  -> Process ()
 startupHalonNode rcClosure = do
-    p <- spawnLocal Storage.runStorage
+    p <- Storage.runStorage
     link p
 
     autoboot rcClosure `catch` \(_ :: SomeException) ->

--- a/halon/src/lib/HA/Storage.hs
+++ b/halon/src/lib/HA/Storage.hs
@@ -91,14 +91,16 @@ delete :: String -> Process ()
 delete = nsend name . Delete . BS.pack
 
 -- | Start a storage process
-runStorage :: Process ()
-runStorage = prepare >> mainloop
+runStorage :: Process ProcessId
+runStorage = do
+    pid <- spawnLocal mainloop
+    prepare pid
+    return pid
   where
-    prepare = do
-      self <- getSelfPid
+    prepare pid = do
       mpid <- whereis name
       case mpid of
-        Nothing -> register name self
+        Nothing -> register name pid
         Just _  -> do
           say "Could not start storage, as previous storage exists."
           error "Storage: takeover procedure is not yet implemented."

--- a/halon/tests/HA/Storage/Tests.hs
+++ b/halon/tests/HA/Storage/Tests.hs
@@ -29,7 +29,7 @@ withProcess node action = do
 tests :: Transport -> IO TestTree
 tests transport = do
   node <- newLocalNode transport remoteTable
-  _    <- forkProcess node $ Storage.runStorage
+  _    <- forkProcess node $ Storage.runStorage >> return ()
   return $ testGroup "HA.Storage"
              [ testCase "get . put == id" $ do
                   assertEqual "read value from storage" (Right (1::Int))


### PR DESCRIPTION
*Created by: facundominguez*

While `startupHalonNode` returns before initialization is complete, it could conflict with later calls to `ignition`.

This is one more effort to make `startupHalonNode` synchronous.
