### PR TITLE
Add timestamps in messages to SSPL.

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -710,7 +710,8 @@ Test-Suite unit-tests
                     amqp,
                     text,
                     aeson,
-                    uuid
+                    uuid,
+                    time
   if flag(mero)
       Build-Depends: rpclite, syb
       CPP-Options:    -DUSE_MERO
@@ -773,7 +774,8 @@ Test-Suite integration-tests
                     amqp,
                     text,
                     aeson,
-                    uuid
+                    uuid,
+                    time
   if flag(rpc)
       Build-Depends: network-transport-rpc
       CPP-Options:    -DUSE_RPC
@@ -832,7 +834,8 @@ Test-Suite scheduler-tests
                     unix,
                     cep,
                     attoparsec,
-                    containers
+                    containers,
+                    time
 
 Test-Suite test-start-service-local
   Type:             exitcode-stdio-1.0

--- a/mero-halon/src/lib/HA/Services/SSPL.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL.hs
@@ -73,6 +73,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.UUID as UID
 import qualified Data.HashMap.Strict as HM
+import Data.Time (getCurrentTime)
 
 import Network.AMQP
 import Network.CEP (Definitions)
@@ -144,9 +145,10 @@ startActuators chan ac pid = do
     commandProcess Rabbit.BindConf{..} rp = forever $ do
       (muuid, cmd) <- receiveChan rp
       uuid <- liftIO $ maybe randomIO return muuid
+      msgTime <- liftIO getCurrentTime
       let msg = encode $ ActuatorRequest {
           actuatorRequestSignature = "Signature-is-not-implemented-yet"
-        , actuatorRequestTime = ""
+        , actuatorRequestTime = formatTimeSSPL msgTime
         , actuatorRequestExpires = Nothing
         , actuatorRequestUsername = "halon"
         , actuatorRequestMessage = ActuatorRequestMessage {

--- a/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
@@ -34,6 +34,7 @@ import Data.Binary (Binary)
 import Data.Defaultable
 import Data.Hashable (Hashable)
 import Data.Monoid ((<>))
+import Data.Time
 import qualified Data.Text as T
 import Data.Typeable (Typeable)
 import Data.UUID (UUID)
@@ -314,6 +315,9 @@ ssplSchema = SSPLConf
             <$> Rabbit.connectionSchema
             <*> sensorSchema
             <*> actuatorSchema
+
+formatTimeSSPL :: UTCTime -> T.Text
+formatTimeSSPL = T.pack . formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%Q"
 
 --------------------------------------------------------------------------------
 -- Dictionaries                                                               --

--- a/mero-halon/tests/HA/Test/SSPL.hs
+++ b/mero-halon/tests/HA/Test/SSPL.hs
@@ -55,6 +55,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text.Encoding as T
 import Data.List (isInfixOf)
 import Data.Maybe (fromJust)
+import Data.Time
 import Data.Typeable
 import qualified Data.UUID as UUID
 import Network.AMQP
@@ -238,10 +239,11 @@ testDelivery transport = runSSPLTest transport interseptor test
                 }} = decodeStrict bs
       Just (SmartTest "foo") <- return $ parseNodeCmd cmd
 
+      msgTime <- liftIO $ getCurrentTime
       let uuid = fromJust $ UUID.fromString "c2cc10e1-57d6-4b6f-9899-38d972112d8c"
       let msg = ActuatorResponse
                   { actuatorResponseSignature = "auth_sig"
-                  , actuatorResponseTime      = "msg_time"
+                  , actuatorResponseTime      = formatTimeSSPL msgTime
                   , actuatorResponseExpires   = Nothing
                   , actuatorResponseUsername  = "ssplll"
                   , actuatorResponseMessage   =


### PR DESCRIPTION
*Created by: qnikst*

Add timestamps to messages that are sent to SSPL, because this is a required field that is used by the service.
