### PR TITLE
SSPL-service: have non empty value in security token.

### DIFF
--- a/mero-halon/src/lib/HA/Services/SSPL.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL.hs
@@ -145,7 +145,7 @@ startActuators chan ac pid = do
       (muuid, cmd) <- receiveChan rp
       uuid <- liftIO $ maybe randomIO return muuid
       let msg = encode $ ActuatorRequest {
-          actuatorRequestSignature = ""
+          actuatorRequestSignature = "Signature-is-not-implemented-yet"
         , actuatorRequestTime = ""
         , actuatorRequestExpires = Nothing
         , actuatorRequestUsername = "halon"


### PR DESCRIPTION
*Created by: qnikst*

SSPL team sayed that empty string in security token will not
pass schema validation. As a result we need to put something
there, until we will implement security token.
