### PR TITLE
mero-halon: Implement a benchmark with 12 satellites.

### DIFF
--- a/mero-halon/benchmarks/halonpings.hs
+++ b/mero-halon/benchmarks/halonpings.hs
@@ -1,0 +1,188 @@
+--
+-- Copyright : (C) 2015 Seagate Technology Limited.
+-- License   : All rights reserved.
+--
+-- This a benchmakr which spawns twelve nodes which send events to the tracking
+-- station during some time. It then gathers space and time statistics.
+--
+
+{-# LANGUAGE TemplateHaskell #-}
+import HA.Stats hiding (__remoteTable)
+import Mero.RemoteTables (meroRemoteTable)
+
+import Control.Concurrent (forkIO)
+import Control.Distributed.Commands.Management (withHostNames)
+import Control.Distributed.Commands.Process
+  ( copyFiles
+  , systemThere
+  , spawnNode
+  , NodeHandle(..)
+  , copyLog
+  , expectLog
+  , __remoteTable
+  )
+import Control.Distributed.Commands.Providers
+  ( getHostAddress
+  , getProvider
+  )
+import HA.Service hiding (__remoteTable)
+import qualified HA.Services.Ping as Ping
+
+import Control.Distributed.Process
+import Control.Distributed.Process.Closure
+import Control.Distributed.Process.Node
+  ( initRemoteTable
+  , newLocalNode
+  , runProcess
+  )
+
+import Control.Monad
+import Data.IORef
+import Data.Function (fix)
+import Data.List (isInfixOf)
+import Data.Maybe (catMaybes)
+
+import Network.Transport.TCP (createTransport, defaultTCPParameters)
+
+import System.Clock
+import System.Environment (getExecutablePath)
+import System.FilePath ((</>), takeDirectory)
+import System.IO
+import System.Timeout (timeout)
+import Text.Printf
+
+
+getBuildPath :: IO FilePath
+getBuildPath = fmap (takeDirectory . takeDirectory) getExecutablePath
+
+main :: IO ()
+main = (>>= maybe (error "test timed out") return) $
+       timeout (20 * 60 * 1000000) $ do
+    hSetBuffering stdout LineBuffering
+    hSetBuffering stderr LineBuffering
+    cp <- getProvider
+
+    buildPath <- getBuildPath
+
+    ip <- getHostAddress
+    Right nt <- createTransport ip "4000" defaultTCPParameters
+    n0 <- newLocalNode nt (meroRemoteTable $ __remoteTable initRemoteTable)
+    statsRef <- newIORef Nothing
+    let nSat     = 12  -- amount of satellites
+        nStation =  5  -- amount of nodes in the tracking station
+        nPings   = 30  -- amount of pings each satellite will do
+
+    withHostNames cp (nStation + nSat) $  \ms@(m0 : _) -> runProcess n0 $ do
+      let mlocs = map (++ ":9000") ms
+          (tsLocs, stLocs) = splitAt nStation mlocs
+          halonctlloc = (++ ":9001")
+
+      say "Copying binaries ..."
+      copyFiles "localhost" ms [ (buildPath </> "halonctl/halonctl", "halonctl")
+                               , (buildPath </> "halond/halond", "halond") ]
+      self <- getSelfPid
+      flip copyLog self $ \(_, _, msg) -> any (`isInfixOf` msg)
+        [ "New replica started"
+        , "Starting from empty graph"
+        , "New node contacted"
+        , "Node succesfully joined"
+        , "started ping service on"
+        , "received DummyEvent"
+        ]
+
+      say "Spawning halond ..."
+      nhs <- forM (zip ms mlocs) $ \(m, mloc) ->
+               spawnNode m ("HALON_TRACING=none ./halond -l " ++ mloc ++ " 2>&1")
+      let nids = map handleGetNodeId nhs
+          (tsNids, stNids) = splitAt nStation nids
+      forM_ nhs $ \nh -> liftIO $ forkIO $ fix $ \loop -> do
+        e <- handleGetInput nh
+        case e of
+          Left rc -> putStrLn $ show (handleGetNodeId nh) ++ ": terminated " ++ show rc
+          Right s -> putStrLn (show (handleGetNodeId nh) ++ ": " ++ s) >> loop
+
+      say "Spawning the tracking station ..."
+      systemThere [m0] ("./halonctl"
+                     ++ " -l " ++ halonctlloc m0
+                     ++ concatMap (\mloc -> " -a " ++ mloc) tsLocs
+                     ++ " bootstrap station"
+                     ++ " -r 2000000"
+                     )
+      forM_ tsNids $ \nid ->
+        expectLog [nid] (isInfixOf "New replica started in legislature://0")
+      expectLog tsNids (isInfixOf "Starting from empty graph.")
+
+      say "Starting satellite nodes ..."
+      systemThere [m0] ("./halonctl"
+                     ++ " -l " ++ halonctlloc m0
+                     ++ concatMap (\mloc -> " -a " ++ mloc) stLocs
+                     ++ " bootstrap satellite"
+                     ++ concatMap (\mloc -> " -t " ++ mloc) tsLocs
+                     )
+      forM_ (zip stNids stLocs) $ \(nid, mloc) -> do
+        expectLog tsNids $ isInfixOf $ "New node contacted: nid://" ++ mloc
+        expectLog [nid] $ isInfixOf "Node succesfully joined the cluster."
+
+      say "Starting ping service ..."
+      systemThere [m0] $ "./halonctl"
+          ++ " -l " ++ halonctlloc m0
+          ++ concatMap (\mloc -> " -a " ++ mloc) stLocs
+          ++ " service ping start"
+          ++ concatMap (\mloc -> " -t " ++ mloc) tsLocs
+          ++ " 2>&1"
+      forM_ stNids $ \nid ->
+        expectLog tsNids $ isInfixOf $ "started ping service on " ++ show nid
+
+      pingPids <- forM stNids $ \nid -> do
+        whereisRemoteAsync nid $ serviceLabel $ serviceName Ping.ping
+        WhereIsReply _ (Just pingPid) <- expect
+        return pingPid
+
+      say "Sending a first ping ..."
+      forM_ pingPids $ \pingPid -> do
+        send pingPid $ show pingPid
+        expectLog tsNids $ isInfixOf $ "received DummyEvent " ++ show pingPid
+
+      say "Starting benchmark ..."
+      tsStats <- forM [1.. nPings `div` 10] $ \i -> do
+        t0 <- liftIO $ getTime Monotonic
+        forM_ [1..10] $ \j ->
+          forM_ pingPids $ \pingPid ->
+            send pingPid $ show (pingPid, i :: Int, j :: Int)
+        forM_ [1..10] $ \j ->
+          forM_ pingPids $ \pingPid ->
+            expectLog tsNids $ isInfixOf $
+              "received DummyEvent " ++ show (pingPid, i, j :: Int)
+        tf <- liftIO $ getTime Monotonic
+        mems <- forM tsNids $ \nid -> do
+          _ <- spawn nid $ $(mkClosure 'getStats) self
+          expect
+        let timeSpecAsSecs = timeSpecAsNanoSecs (diffTimeSpec tf t0)
+                               `div` 10^(9 :: Int)
+            mem = case catMaybes mems of
+              xs | length xs == length tsNids -> Just (maximum xs :: Integer)
+              _                               -> Nothing
+        return (timeSpecAsSecs, mem)
+
+      let (ts, mems) = unzip tsStats
+      liftIO $ writeIORef statsRef $ Just $
+        zip3 (map (* nSat) [10 :: Int, 20..]) (scanl1 (+) ts) mems
+
+    Just tsStats <- readIORef statsRef
+    putStrLn $ unlines $
+      [ ""
+      , ""
+      , "Started " ++ show nStation ++ " tracking station nodes and " ++
+        show nSat ++ " satellites."
+      , ""
+      , "    pings   time (secs)  memory (kBs)"
+      ] ++
+      map (\(pings, ts, mem) ->
+            printf "%8d  %12d  %12s" pings ts (maybe "unavailable" show mem))
+          tsStats
+      ++
+      [ ""
+      , "The memory column lists the maximum peak resident memory size in"
+      , "any tracking station."
+      ]
+

--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -25,6 +25,10 @@ Flag distributed-tests
   Description: Enables distributed tests.
   Default: False
 
+Flag distributed-benchmarks
+  Description: Enables distributed benchmarks.
+  Default: False
+
 Flag rpc
   Description: Build with the RPC backend instead of TCP.
   Default: False
@@ -79,6 +83,7 @@ Library
                    HA.Services.SSPL.CEP
                    HA.Services.SSPLHL
                    HA.Services.SSPL.LL.Resources
+                   HA.Stats
                    HA.RecoveryCoordinator.Mero
                    HA.RecoveryCoordinator.CEP
                    HA.RecoveryCoordinator.Definitions
@@ -885,3 +890,27 @@ Test-Suite test-stha-local
                    unix
   else
       Buildable: False
+
+benchmark halonpings
+  Type:             exitcode-stdio-1.0
+  default-language: Haskell2010
+  Hs-Source-Dirs:  benchmarks
+  Main-Is:         halonpings.hs
+
+  Ghc-Options: -threaded -Wall
+
+  if flag(maintainer)
+    Ghc-Options: -Werror
+
+  if flag(distributed-benchmarks)
+    Build-Depends: distributed-process,
+                   base,
+                   clock,
+                   filepath,
+                   halon,
+                   mero-halon,
+                   network-transport,
+                   network-transport-tcp,
+                   distributed-commands
+  else
+    Buildable:     False

--- a/mero-halon/src/lib/HA/Stats.hs
+++ b/mero-halon/src/lib/HA/Stats.hs
@@ -1,0 +1,30 @@
+--
+-- Copyright : (C) 2015 Seagate Technology Limited.
+-- License   : All rights reserved.
+--
+
+{-# LANGUAGE TemplateHaskell #-}
+module HA.Stats where
+
+import Control.Distributed.Process
+import Control.Distributed.Process.Closure
+import Control.Monad
+import Data.List
+
+
+-- | Send the peak resident set size in kBs in 'Integer' form to the given
+-- process.
+getStats :: ProcessId -> Process ()
+getStats caller = do
+    m <- liftIO $
+      (fmap (drop 1 . words) . find ("VmHWM:" `isPrefixOf`) . lines)
+        <$> readFile "/proc/self/status"
+    usend caller $ join $ fmap readMem m
+  where
+    readMem :: [String] -> Maybe Integer
+    readMem [num, "kB"] = case reads num of
+      (i,_) : _ -> Just i
+      _        -> Nothing
+    readMem _           = Nothing
+
+remotable ['getStats]

--- a/mero-halon/src/lib/Mero/RemoteTables.hs
+++ b/mero-halon/src/lib/Mero/RemoteTables.hs
@@ -18,6 +18,7 @@ import HA.Services.Frontier ( __remoteTable, __remoteTableDecl )
 import HA.Services.Monitor ( __remoteTable, __remoteTableDecl )
 import HA.Services.SSPL ( __remoteTable, __remoteTableDecl )
 import HA.Services.SSPLHL ( __remoteTable, __remoteTableDecl )
+import HA.Stats ( __remoteTable )
 import HA.RecoveryCoordinator.Definitions ( __remoteTable )
 
 import Control.Distributed.Process (RemoteTable)
@@ -41,5 +42,6 @@ meroRemoteTable next =
    HA.Services.DecisionLog.__remoteTableDecl $
    HA.Services.Monitor.__remoteTable $
    HA.Services.Monitor.__remoteTableDecl $
+   HA.Stats.__remoteTable $
    HA.RecoveryCoordinator.Definitions.__remoteTable $
    next


### PR DESCRIPTION
*Created by: facundominguez*

@nc6, see if this is what you had in mind. It is missing the bit about loading initial configuration for which I'm awaiting the details.

It produces output as the following.

```
Started 3 tracking station nodes and 12 satellites.

    pings   time (secs)  memory (kBs)
     120            17        165844
     240            35        212272
     360            55        245000

The memory column lists the maximum peak resident memory size in
any tracking station.
```

Now halon needs to be optimized.
