### PR TITLE
Fix probems with Serializable instance for Bitmap.

### DIFF
--- a/confc/Mero/Conf/Context.hsc
+++ b/confc/Mero/Conf/Context.hsc
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 -- |
 -- Copyright : (C) 2015 Seagate Technology Limited.
@@ -28,6 +29,7 @@ import Foreign.Ptr
   ( plusPtr )
 import Foreign.Storable
   ( Storable(..) )
+import GHC.Generics
 
 import qualified Language.C.Inline as C
 import qualified Language.C.Inline.Context as C
@@ -41,21 +43,26 @@ import qualified Language.C.Types as C
 #let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__);}, y__)
 
 -- @bitmap.h m0_bitmap@
-newtype Bitmap = Bitmap [Word64]
-  deriving (Binary, Eq, Hashable, Show)
+data Bitmap = Bitmap Int [Word64]
+  deriving (Eq, Show, Generic)
+
+instance Binary Bitmap
+instance Hashable Bitmap
 
 instance Storable Bitmap where
   sizeOf _ = #{size struct m0_bitmap}
   alignment _ = #{alignment struct m0_bitmap}
   peek p = do
-      nr <- bits2words <$> (#{peek struct m0_bitmap, b_nr} p)
-      w <- (peekArray nr (#{ptr struct m0_bitmap, b_words} p) :: IO [Word64])
-      return $ Bitmap w
+      nr <- (#{peek struct m0_bitmap, b_nr} p)
+      let wordsn = bits2words nr
+      ptr <- #{peek struct m0_bitmap, b_words} p
+      w <- (peekArray wordsn ptr :: IO [Word64])
+      return $ Bitmap nr w
     where
       bits2words bits = (bits + 63) `shiftR` 6
 
-  poke p (Bitmap b) = do
-      #{poke struct m0_bitmap, b_nr} p $ 64 * length b
+  poke p (Bitmap nr b) = do
+      #{poke struct m0_bitmap, b_nr} p nr
       -- TODO This memory is never freed
       words_ptr <- newArray b
       #{poke struct m0_bitmap, b_words} p words_ptr

--- a/confc/confc.cabal
+++ b/confc/confc.cabal
@@ -1,5 +1,5 @@
 Name:          confc
-Version:       0.0.2
+Version:       0.0.3
 Synopsis:      Bindings for Mero configuration client library.
 Description:   The Mero configuration client library allows programs
                to contact the confd service.
@@ -17,8 +17,8 @@ Library
   Default-Language:    Haskell2010
   exposed-modules:     Mero.ConfC
                      , Mero.Spiel
-  other-modules:       Mero.Conf.Context
-                     , Mero.Conf.Fid
+                     , Mero.Conf.Context
+  other-modules:       Mero.Conf.Fid
                      , Mero.Conf.Internal
                      , Mero.Conf.Obj
                      , Mero.Conf.Tree
@@ -109,3 +109,21 @@ Test-Suite testcopyconf
                    filepath,
                    rpclite,
                    time >= 1.4
+
+Test-Suite unit-tests 
+  Type:             exitcode-stdio-1.0
+  default-language: Haskell2010
+  Hs-Source-Dirs:   tests/
+  Main-Is:          ut.hs
+  c-sources:        tests/ut.c
+  cc-options: -Wno-attributes -Werror -g -DM0_INTERNAL= -DM0_EXTERN=extern
+  Ghc-Options: -threaded -Wall
+  if flag(maintainer)
+    Ghc-Options: -Werror
+  Build-Depends:   confc >= 0.0.3,
+                   base >= 4.5,
+                   inline-c,
+                   tasty,
+                   tasty-hunit,
+                   rpclite
+  extra-libraries: mero

--- a/confc/tests/ut.hs
+++ b/confc/tests/ut.hs
@@ -1,0 +1,60 @@
+--
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Main where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Monoid
+import Foreign
+
+import Mero
+import Mero.Conf.Context
+import qualified Language.C.Inline as C
+
+C.context (C.baseCtx <> confCtx)
+C.include "lib/bitmap.h"
+
+main :: IO ()
+main = withM0 $ defaultMain tests
+
+tests :: TestTree
+tests = testGroup "ut"
+  [ testGroup "bitmap" 
+      [ testCase "peek-poke == id" testPeekPoke
+      ]
+  ]
+
+testPeekPoke :: Assertion
+testPeekPoke = alloca $ \bm_ptr -> do
+  [C.block| void {
+      struct m0_bitmap * bm = $(struct m0_bitmap* bm_ptr);
+      m0_bitmap_init(bm, 32);
+      m0_bitmap_set(bm, 0, true);
+      m0_bitmap_set(bm, 1, false);
+    }|]
+  -- check old values as they are observable by C code
+  cN    <- [C.exp| size_t { $(struct m0_bitmap* bm_ptr)->b_nr } |]
+  cWord <- [C.exp| uint64_t { $(struct m0_bitmap *bm_ptr)->b_words[0] } |]
+  bitmap@(Bitmap haskellN haskellWords)  <- peek bm_ptr
+  -- check values as they are observable by Haskell
+  assertEqual "Haskell read size correctly" cN (fromIntegral haskellN)
+  assertEqual "Haskell read only one uint64_t element" 1 (length haskellWords)
+  assertEqual "Haskell read data correctly" cWord (head haskellWords)
+  -- poke value back
+  poke bm_ptr bitmap
+  -- test that value is still correct
+  cNNew <- [C.exp| size_t { $(struct m0_bitmap* bm_ptr)->b_nr } |]
+  assertEqual "Bitmap size after poke is correct" cN cNNew
+  i <- [C.block| int {
+          struct m0_bitmap * bm = $(struct m0_bitmap* bm_ptr);
+          bool b=0;
+          int ret=0;
+          b = m0_bitmap_get(bm, 0);
+          ret += b?1:0;
+          b = m0_bitmap_get(bm, 0);
+          ret += b?2:0;
+          return ret;
+        }|]
+  assertEqual "Bitmap data after poke is correct" 3 i


### PR DESCRIPTION
*Created by: qnikst*

Fix memory corruption in peek. Keep size of the bitmap in
order to not lose it in poke.
