### PR TITLE
Fix Bitmap allocation.

### DIFF
--- a/confc/Mero/Spiel.hs
+++ b/confc/Mero/Spiel.hs
@@ -227,7 +227,7 @@ addProcess (SpielTransaction fsc) fid nodeFid bitmap memlimit_as memlimit_rss
             memlimit_stack memlimit_memlock endpoint =
   withForeignPtr fsc $ \sc ->
     withMany with [fid, nodeFid] $ \[fid_ptr, fs_ptr] ->
-      with bitmap $ \bm_ptr ->
+      withBitmap bitmap $ \bm_ptr ->
         withCString endpoint $ \c_ep ->
           throwIfNonZero_ (\rc -> "Cannot add process: " ++ show rc)
             $ c_spiel_process_add sc fid_ptr fs_ptr bm_ptr memlimit_as

--- a/confc/confc.cabal
+++ b/confc/confc.cabal
@@ -17,11 +17,11 @@ Library
   Default-Language:    Haskell2010
   exposed-modules:     Mero.ConfC
                      , Mero.Spiel
-                     , Mero.Conf.Context
   other-modules:       Mero.Conf.Fid
                      , Mero.Conf.Internal
                      , Mero.Conf.Obj
                      , Mero.Conf.Tree
+                     , Mero.Conf.Context
                      , Mero.Spiel.Context
                      , Mero.Spiel.Internal
   build-depends:       base
@@ -38,6 +38,7 @@ Library
   ghc-options:  -Wall -fprof-auto -fprof-auto-calls -fPIC -optc-Wno-attributes
                 -optc-Werror -optc-g -optc-DM0_INTERNAL= -optc-DM0_EXTERN=extern
   default-extensions:  CPP
+  other-extensions:    TemplateHaskell, QuasiQuotes, CApiFFI
   if flag(maintainer)
     ghc-options: -Werror
 


### PR DESCRIPTION
*Created by: qnikst*

With this fix bitmap is only allocated on mero side and is
freed accordinly. Thus we do not introduce memory leaks.
