### PR TITLE
Add an additional status command to directly query node status.

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -87,6 +87,7 @@ Library
                    HA.RecoveryCoordinator.Mero
                    HA.RecoveryCoordinator.CEP
                    HA.RecoveryCoordinator.Definitions
+                   HA.RecoveryCoordinator.Events.Status
                    HA.RecoveryCoordinator.Actions.Core
                    HA.RecoveryCoordinator.Actions.Hardware
                    HA.RecoveryCoordinator.Actions.Service

--- a/mero-halon/src/halonctl/Flags.hs
+++ b/mero-halon/src/halonctl/Flags.hs
@@ -17,6 +17,7 @@ import qualified Options.Applicative.Extras as O
 
 import qualified Handler.Service as Service
 import qualified Handler.Cluster as Cluster
+import qualified Handler.Status as Status
 
 import System.Environment (getProgName)
 import System.IO.Unsafe (unsafePerformIO)
@@ -33,6 +34,7 @@ data Command =
       Bootstrap Bootstrap.BootstrapCmdOptions
     | Service Service.ServiceCmdOptions
     | Cluster Cluster.ClusterOptions
+    | Status Status.StatusOptions
   deriving (Eq)
 
 getOptions :: IO Options
@@ -59,6 +61,8 @@ getOptions = do
                     O.withDesc Service.parseService "Control services.")
               <> (O.command "cluster" $ Cluster <$>
                     O.withDesc Cluster.parseCluster "Control cluster wide options.")
+              <> (O.command "status" $ Status <$>
+                    O.withDesc Status.parseStatus "Query node status.")
             )
     hostname = unsafePerformIO $ readProcess "hostname" [] ""
     listenAddr = hostname ++ ":9001"

--- a/mero-halon/src/halonctl/Handler/Status.hs
+++ b/mero-halon/src/halonctl/Handler/Status.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE RecordWildCards            #-}
+-- |
+-- Copyright : (C) 2015 Seagate Technology Limited.
+-- License   : All rights reserved.
+--
+-- Querying status of nodes.
+
+module Handler.Status
+  ( StatusOptions
+  , parseStatus
+  , status
+  ) where
+
+import HA.EventQueue.Producer (promulgateEQ)
+import HA.RecoveryCoordinator.Events.Status
+import HA.Resources
+
+import Lookup
+
+import Control.Distributed.Process
+import Control.Monad (join)
+
+import Data.Monoid ((<>))
+
+import qualified Options.Applicative as O
+
+data StatusOptions = StatusOptions
+    Int
+  deriving (Eq, Show)
+
+parseStatus :: O.Parser StatusOptions
+parseStatus = StatusOptions
+  <$> O.option O.auto (
+        O.metavar "TIMEOUT (μs)"
+        <> O.long "eqt-timeout"
+        <> O.value 1000000
+        <> O.help ("Time to wait from a reply from the EQT when" ++
+                  " querying the location of an EQ.")
+      )
+
+status :: [NodeId] -> StatusOptions -> Process ()
+status nids (StatusOptions t) = do
+    self <- getSelfPid
+    eqs <- findEQFromNodes t nids
+    resp <- mapM (go self eqs) nids
+    let stats = zip nids resp
+    mapM_ (liftIO . putStrLn . display) stats
+  where
+    go self eqs nid = do
+        promulgateEQ eqs msg >>= \pid -> withMonitor pid wait
+      where
+        msg = NodeStatusRequest (Node nid) [self]
+        wait = do
+          _ <- expect :: Process ProcessMonitorNotification
+          expectTimeout t
+    display (nid, Nothing) = show nid ++ ": No reply from RC."
+    display (nid, Just (NodeStatusResponse{..})) = join $
+        [ show nid ++ ":"
+        , "\n\t" ++ ts
+        , "\n\t" ++ sat
+        ]
+      where
+        ts = if nsrIsStation
+              then "is a tracking station node."
+              else "is not a tracking station node."
+        sat = if nsrIsSatellite
+              then "is a satellite node."
+              else "is not a satellite node."

--- a/mero-halon/src/halonctl/Main.hs
+++ b/mero-halon/src/halonctl/Main.hs
@@ -14,6 +14,7 @@ import HA.Network.RemoteTables (haRemoteTable)
 import Handler.Bootstrap
 import Handler.Cluster
 import Handler.Service
+import Handler.Status
 
 import Mero.RemoteTables (meroRemoteTable)
 
@@ -90,6 +91,7 @@ run (Options { .. }) = do
           Bootstrap bs -> bootstrap rnids bs
           Service bs   -> service rnids bs
           Cluster bs   -> cluster rnids bs
+          Status  bs   -> status rnids bs
       else do
         say "Failed to connect to controlled nodes: "
         liftIO $ mapM_ putStrLn $ concat replies

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Status.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Status.hs
@@ -1,0 +1,34 @@
+-- |
+-- Copyright : (C) 2015 Seagate Technology Limited.
+-- License   : All rights reserved.
+--
+
+module HA.RecoveryCoordinator.Events.Status where
+
+import HA.Resources
+
+import Control.Distributed.Process (ProcessId)
+
+import Data.Binary   (Binary)
+import Data.Hashable (Hashable)
+import Data.Typeable (Typeable)
+
+import GHC.Generics
+
+-- ^ Sent when a process wishes to enquire about the status of a node.
+data NodeStatusRequest =
+    NodeStatusRequest Node [ProcessId]
+  deriving (Eq, Show, Typeable, Generic)
+
+instance Hashable NodeStatusRequest
+instance Binary NodeStatusRequest
+
+-- ^ Response to a query about the status of a node.
+data NodeStatusResponse = NodeStatusResponse
+  { nsrNode :: Node
+  , nsrIsStation :: Bool
+  , nsrIsSatellite :: Bool
+  } deriving (Eq, Show, Typeable, Generic)
+
+instance Hashable NodeStatusResponse
+instance Binary NodeStatusResponse


### PR DESCRIPTION
*Created by: nc6*

```
[devvm@devvm halon]$ hctl -a 127.0.0.1:9010 status
This is halonctl/TCP
nid://127.0.0.1:9010:0:
        is a tracking station node.
        is not a satellite node.
[devvm@devvm halon]$ hctl -a 127.0.0.1:9510 status
This is halonctl/TCP
Error connecting to nid://127.0.0.1:9510:0: node disconnected.
Wed Nov 25 16:15:09 UTC 2015 pid://127.0.0.1:9001:0:10: Failed to connect to controlled nodes: 
[devvm@devvm halon]$ hctl -a 127.0.0.1:9500 status
This is halonctl/TCP
nid://127.0.0.1:9500:0:
        is not a tracking station node.
        is a satellite node.
```
