### PR TITLE
Dispatch messages in SSPL service.

### DIFF
--- a/mero-halon/tests/HA/Castor/Story/Tests.hs
+++ b/mero-halon/tests/HA/Castor/Story/Tests.hs
@@ -521,9 +521,10 @@ testDriveRemovedBySSPL transport = run transport interceptor test where
         message0 = LBS.toStrict $ encode
                                 $ mkSensorResponse
                                 $ mkResponseHPI host (fromIntegral devIdx) "/dev/loop1" "wwn1"
-        message = LBS.toStrict $ encode 
-                               $ mkSensorResponse
-                               $ mkResponseDriveManager (pack enclosure) devIdx "unused_ok"
+        message = LBS.toStrict $ encode $ mkSensorResponse
+           $ emptySensorMessage
+              { sensorResponseMessageSensor_response_typeDisk_status_drivemanager =
+                Just $ mkResponseDriveManager (pack enclosure) devIdx "unused_ok" }
     usend rmq $ MQPublish "sspl_halon" "sspl_ll" message0
     usend rmq $ MQPublish "sspl_halon" "sspl_ll" message
     _ <- expect :: Process (Published DriveRemoved)

--- a/mero-halon/tests/HA/RecoveryCoordinator/Mero/Tests.hs
+++ b/mero-halon/tests/HA/RecoveryCoordinator/Mero/Tests.hs
@@ -273,19 +273,8 @@ testHostAddition transport = do
     wait = void (expect :: Process ProcessMonitorNotification)
     rt = TestRunner.__remoteTableDecl $
          remoteTable
-    mockEvent = emptySensorMessage { SSPL.sensorResponseMessageSensor_response_typeHost_update =
-      Just $ SSPL.SensorResponseMessageSensor_response_typeHost_update
-        { SSPL.sensorResponseMessageSensor_response_typeHost_updateRunningProcessCount = Nothing
-        , SSPL.sensorResponseMessageSensor_response_typeHost_updateUname               = Just "mockhost"
-        , SSPL.sensorResponseMessageSensor_response_typeHost_updateHostId              = "mockhost"
-        , SSPL.sensorResponseMessageSensor_response_typeHost_updateLocaltime           = ""
-        , SSPL.sensorResponseMessageSensor_response_typeHost_updateUpTime              = Nothing
-        , SSPL.sensorResponseMessageSensor_response_typeHost_updateFreeMem             = Nothing
-        , SSPL.sensorResponseMessageSensor_response_typeHost_updateLoggedInUsers       = Nothing
-        , SSPL.sensorResponseMessageSensor_response_typeHost_updateTotalMem            = Nothing
-        , SSPL.sensorResponseMessageSensor_response_typeHost_updateProcessCount        = Nothing
-        , SSPL.sensorResponseMessageSensor_response_typeHost_updateBootTime            = Nothing
-        }
+    mockEvent = (emptyHostUpdate "mockhost")
+      { SSPL.sensorResponseMessageSensor_response_typeHost_updateUname = Just "mockhost"
       }
 
 -- | Test that the recovery co-ordinator successfully adds a drive to the RG,

--- a/mero-halon/tests/HA/RecoveryCoordinator/SSPL/Tests.hs
+++ b/mero-halon/tests/HA/RecoveryCoordinator/SSPL/Tests.hs
@@ -98,7 +98,7 @@ utTests transport = testGroup "Service-SSPL"
    $ testDMRequest transport 
    ]
 
-dmRequest :: Text -> Int -> SensorResponseMessageSensor_response_type
+dmRequest :: Text -> Int -> SensorResponseMessageSensor_response_typeDisk_status_drivemanager
 dmRequest status num = mkResponseDriveManager "enclosure1" (fromIntegral num) status
 
 mkHpiTest :: (ProcessId -> Definitions LoopState b)

--- a/mero-halon/tests/HA/Test/SSPL.hs
+++ b/mero-halon/tests/HA/Test/SSPL.hs
@@ -68,7 +68,7 @@ data RChan = RChan String deriving (Generic, Typeable)
 
 instance Binary RChan
 
-data SChan = SChan SensorResponseMessageSensor_response_type deriving (Generic, Typeable)
+data SChan = SChan SensorResponseMessageSensor_response_typeHost_update deriving (Generic, Typeable)
 
 instance Binary SChan
 
@@ -220,7 +220,8 @@ testSensor transport = runSSPLTest transport interseptor test
             , ", \"time\": \"2015-10-19 11:49:34.706694\""
             , ", \"message\": {\"sspl_ll_msg_header\": {\"msg_version\": \"1.0.0\", \"schema_version\": \"1.0.0\", \"sspl_version\": \"1.0.0\"}, \"sensor_response_type\": {\"host_update\": {\"loggedInUsers\": [\"vagrant\"], \"runningProcessCount\": 2, \"hostId\": \"devvm.seagate.com\", \"totalMem\": {\"units\": \"MB\", \"value\": 1930}, \"upTime\": 1445251379, \"uname\": \"Linux devvm.seagate.com 3.10.0-229.7.2.el7.x86_64 #1 SMP Tue Jun 23 22:06:11 UTC 2015 x86_64\", \"bootTime\": \"2015-10-19 10:42:59 \", \"processCount\": 126, \"freeMem\": {\"units\": \"MB\", \"value\": 142}, \"localtime\": \"2015-10-19 11:49:34 \"}}}}"
             ] :: ByteString
-          Just msg = sensorResponseMessageSensor_response_type
+          Just (Just msg) = sensorResponseMessageSensor_response_typeHost_update
+            . sensorResponseMessageSensor_response_type
             . sensorResponseMessage <$> decodeStrict rawmsg
       say "sending command"
       usend pid $ MQPublish "sspl_halon" "sspl_ll" rawmsg

--- a/mero-halon/tests/Helper/SSPL.hs
+++ b/mero-halon/tests/Helper/SSPL.hs
@@ -2,6 +2,7 @@
 module Helper.SSPL 
   ( emptySensorMessage
   , emptyHPIMessage
+  , emptyHostUpdate
   , mkSensorResponse
   , mkResponseDriveManager
   , mkResponseHPI
@@ -47,20 +48,32 @@ emptyHPIMessage = SSPL.SensorResponseMessageSensor_response_typeDisk_status_hpi
   , SSPL.sensorResponseMessageSensor_response_typeDisk_status_hpiProductVersion = "0.0.1"
   }
 
+emptyHostUpdate :: Text -> SSPL.SensorResponseMessageSensor_response_typeHost_update
+emptyHostUpdate hostid = 
+  SSPL.SensorResponseMessageSensor_response_typeHost_update
+    { SSPL.sensorResponseMessageSensor_response_typeHost_updateRunningProcessCount = Nothing
+    , SSPL.sensorResponseMessageSensor_response_typeHost_updateUname               = Nothing
+    , SSPL.sensorResponseMessageSensor_response_typeHost_updateHostId              = hostid
+    , SSPL.sensorResponseMessageSensor_response_typeHost_updateLocaltime           = ""
+    , SSPL.sensorResponseMessageSensor_response_typeHost_updateUpTime              = Nothing
+    , SSPL.sensorResponseMessageSensor_response_typeHost_updateFreeMem             = Nothing
+    , SSPL.sensorResponseMessageSensor_response_typeHost_updateLoggedInUsers       = Nothing
+    , SSPL.sensorResponseMessageSensor_response_typeHost_updateTotalMem            = Nothing
+    , SSPL.sensorResponseMessageSensor_response_typeHost_updateProcessCount        = Nothing
+    , SSPL.sensorResponseMessageSensor_response_typeHost_updateBootTime            = Nothing
+    }
+
 -- | Create drive manager message
 mkResponseDriveManager :: Text -- ^ Enclosure SN
                        -> Int  -- ^ Disk Num
                        -> Text -- ^ Status
-                       -> SSPL.SensorResponseMessageSensor_response_type
+                       -> SSPL.SensorResponseMessageSensor_response_typeDisk_status_drivemanager
 mkResponseDriveManager enclosure idx status =
-   emptySensorMessage
-     { SSPL.sensorResponseMessageSensor_response_typeDisk_status_drivemanager =
-         Just $ SSPL.SensorResponseMessageSensor_response_typeDisk_status_drivemanager
-           { SSPL.sensorResponseMessageSensor_response_typeDisk_status_drivemanagerEnclosureSN = enclosure
-           , SSPL.sensorResponseMessageSensor_response_typeDisk_status_drivemanagerDiskNum     = fromIntegral idx
-           , SSPL.sensorResponseMessageSensor_response_typeDisk_status_drivemanagerDiskStatus  = status
-           }
-     }
+  SSPL.SensorResponseMessageSensor_response_typeDisk_status_drivemanager
+    { SSPL.sensorResponseMessageSensor_response_typeDisk_status_drivemanagerEnclosureSN = enclosure
+    , SSPL.sensorResponseMessageSensor_response_typeDisk_status_drivemanagerDiskNum     = fromIntegral idx
+    , SSPL.sensorResponseMessageSensor_response_typeDisk_status_drivemanagerDiskStatus  = status
+    }
 
 mkResponseHPI :: Text -- ^ Host ID of node
               -> Integer -- ^ Location number of drive


### PR DESCRIPTION
*Created by: qnikst*

Move message dispatching logic from SSPL RC rules to SSPL service.
This makes RC rules simpler as they are interested only in certain
types of the rules. As an additional effect we reduce amount of
pressure on CPU (as we no longer seek in the queue with irrelevant
messages) and memory as we no longer keep messages that are not
needed in the rule queue.
