### PR TITLE
Bootstrap node and start decision-log on TS

### DIFF
--- a/mero-halon/scripts/localcluster
+++ b/mero-halon/scripts/localcluster
@@ -28,7 +28,7 @@ HALOND="$HALON_ROOT/halond +RTS $HALON_RTS_OPTS -RTS"
 HALONCTL="$HALON_ROOT/halonctl"
 
 # Clean up anything currently running
-pkill halond || /bin/true 
+pkill halond || /bin/true
 
 # Build the arrays of addresses
 i=0


### PR DESCRIPTION
*Created by: Fuuzetsu*

We now notify halonctl users that d-l can only run on TS nodes and
don't attempt to start the service at all if that's not the case. This
is not resillent to user directly promulgating a start service request
as I'm unsure we want that.
