### PR TITLE
Fix wrong parse of the disk_parent field.

### DIFF
--- a/confc/Mero/Conf/Obj.hsc
+++ b/confc/Mero/Conf/Obj.hsc
@@ -413,7 +413,7 @@ getController po =
 data Sdev = Sdev
   { sd_ptr        :: Ptr Obj
   , sd_fid        :: Fid
-  , sd_disk       :: Maybe Fid
+  , sd_disk       :: Ptr Fid
   , sd_iface      :: Word32
   , sd_media      :: Word32
   , sd_bsize      :: Word32
@@ -427,7 +427,7 @@ getSdev :: Ptr Obj -> IO Sdev
 getSdev po = do
   ps <- confc_cast_sdev po
   fid   <- #{peek struct m0_conf_obj, co_id} po
-  mdisk <- maybePeek #{peek struct m0_conf_sdev, sd_disk} po
+  mdisk <- #{peek struct m0_conf_sdev, sd_disk} ps
   iface <- #{peek struct m0_conf_sdev, sd_iface} ps
   media <- #{peek struct m0_conf_sdev, sd_media} ps
   bsize <- #{peek struct m0_conf_sdev, sd_bsize} ps

--- a/confc/Mero/Spiel.hs
+++ b/confc/Mero/Spiel.hs
@@ -36,6 +36,7 @@ import Foreign.C.String
   )
 import Foreign.C.Types
   ( CUInt(..) )
+import Foreign.Ptr (Ptr)
 import Foreign.ForeignPtr
   ( ForeignPtr
   , mallocForeignPtrBytes
@@ -56,6 +57,7 @@ import Foreign.Marshal.Utils
   , with
   , withMany
   , maybeWith
+  , maybePeek
   )
 import Foreign.Ptr
   ( nullPtr )
@@ -517,7 +519,8 @@ instance Spliceable Service where
 
 instance Spliceable Sdev where
   splice t p o = do
-     addDevice t (sd_fid o) p (sd_disk o)
+     msd <- maybePeek peek (sd_disk o)
+     addDevice t (sd_fid o) p msd
                (toEnum . fromIntegral $ sd_iface o)
                (toEnum . fromIntegral $ sd_media o)
                (sd_bsize o) (sd_size o)


### PR DESCRIPTION
*Created by: qnikst*

Fix incorrect read of the disk_parent field in `m0_conf_sdev` structure.
