### PR TITLE
rpclite: Implement finalizers called before m0_fini.

### DIFF
--- a/mero-halon/src/lib/Mero/Notification.hs
+++ b/mero-halon/src/lib/Mero/Notification.hs
@@ -175,6 +175,7 @@ initializeInternal addr = liftIO (takeMVar globalEndpointRef) >>= \ref -> case r
       (liftM0 $ do
         initRPC
         ep <- listen addr listenCallbacks
+        addM0Finalizer $ finalizeInternal globalEndpointRef
         let ref' = emptyEndpointRef { _erServerEndpoint = Just ep }
         return (globalEndpointRef, ref', ep))
       (liftIO $ putMVar globalEndpointRef ref)

--- a/rpclite/Mero.hsc
+++ b/rpclite/Mero.hsc
@@ -18,6 +18,7 @@ module Mero
   , sendM0Task_
   , M0InitException(..)
   , setNodeUUID
+  , addM0Finalizer
   ) where
 
 import Mero.Concurrent
@@ -135,7 +136,10 @@ withM0Deferred f = do
 foreign import ccall m0_init_wrapper :: IO CInt
 
 -- | Finalizes mero.
-foreign import ccall m0_fini :: IO ()
+foreign import ccall "m0_fini" c_m0_fini :: IO ()
+
+m0_fini :: IO ()
+m0_fini = finalizeM0 >> c_m0_fini
 
 foreign import ccall "<lib/uuid.h> m0_node_uuid_string_set"
   c_node_uuid_string_set  :: CString -> IO ()

--- a/rpclite/Mero/Concurrent.hsc
+++ b/rpclite/Mero/Concurrent.hsc
@@ -6,15 +6,27 @@
 --
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE EmptyDataDecls           #-}
-module Mero.Concurrent (forkM0OS, joinM0OS, m0ThreadId, M0Thread) where
+{-# LANGUAGE LambdaCase               #-}
+module Mero.Concurrent
+  ( forkM0OS
+  , joinM0OS
+  , m0ThreadId
+  , M0Thread
+  , finalizeM0
+  , addM0Finalizer
+  ) where
 
-import Control.Concurrent      (myThreadId, ThreadId, rtsSupportsBoundThreads)
+import Control.Concurrent      (myThreadId, ThreadId, rtsSupportsBoundThreads, killThread)
 import Control.Concurrent.MVar
 import Control.Monad           (when)
 import Foreign.C.Types         (CInt(..))
 import Foreign.Marshal.Alloc   (mallocBytes)
 import Foreign.Ptr             (FunPtr, Ptr)
+import Data.Foldable           (forM_)
+import System.IO.Unsafe        (unsafePerformIO)
+import Data.IORef              (IORef, newIORef, modifyIORef, atomicModifyIORef)
 
+import System.IO
 #include "lib/thread.h"
 
 
@@ -22,7 +34,15 @@ import Foreign.Ptr             (FunPtr, Ptr)
 data M0Thread = M0Thread
    { _m0ThreadId :: ThreadId
    , _m0ThreadPtr :: Ptr M0Thread
-   } deriving Show
+   , _m0ThreadJoined :: MVar Bool
+   }
+
+instance Show M0Thread where
+  show (M0Thread a b c) = "M0Thread "++show a++" "++show b++" <lock>"
+
+globalFinalizers :: IORef [(Maybe ThreadId, IO ())]
+globalFinalizers = unsafePerformIO $ newIORef []
+{-# NOINLINE globalFinalizers #-}
 
 -- | Creates a bound m0_thread.
 --
@@ -39,7 +59,10 @@ forkM0OS action | rtsSupportsBoundThreads = do
     when (rc /= 0) $
       fail "forkM0OS: Cannot create m0_thread."
     tid <- takeMVar mv
-    return $ M0Thread tid ptr
+    vv  <- newMVar False
+    let mt = M0Thread tid ptr vv
+    modifyIORef globalFinalizers ((Just tid, killThread tid >> joinM0OS mt):)
+    return mt
 forkM0OS _ = fail $ "forkM0OS: RTS doesn't support multiple OS threads "
                     ++"(use ghc -threaded when linking)"
 
@@ -48,9 +71,14 @@ forkM0OS _ = fail $ "forkM0OS: RTS doesn't support multiple OS threads "
 -- This call can happen only in an m0_thread.
 joinM0OS :: M0Thread -> IO ()
 joinM0OS m0t = do
-    rc <- forkM0OS_joinThread (_m0ThreadPtr m0t)
-    when (rc /= 0) $
-      fail $ "joinM0OS: Cannot join m0_thread " ++ show m0t ++ ": " ++ show rc
+    modifyMVar_ (_m0ThreadJoined m0t) $ \case
+      True -> return True
+      False -> do
+        rc <- forkM0OS_joinThread (_m0ThreadPtr m0t)
+        when (rc /= 0) $
+          fail $ "joinM0OS: Cannot join m0_thread " ++ show m0t ++ ": " ++ show rc
+        modifyIORef globalFinalizers $ filter (( /= (Just $ _m0ThreadId m0t)) . fst)
+        return True
 
 -- | Yields the 'ThreadId' associated with an m0_thread.
 m0ThreadId :: M0Thread -> ThreadId
@@ -62,3 +90,14 @@ foreign import ccall forkM0OS_createThread ::
 foreign import ccall "wrapper" cwrapAction :: IO () -> IO (FunPtr (IO ()))
 
 foreign import ccall forkM0OS_joinThread :: Ptr M0Thread -> IO CInt
+
+finalizeM0 :: IO ()
+finalizeM0 = do
+  list <- atomicModifyIORef globalFinalizers (\x -> ([], x))
+  forM_ list $ \(_, a) -> a
+
+-- | Adds an action that will be called just before 'Mero.m0_fini' is called.
+-- Adding finalizers after calling to m0_fini may lead to a mero failure,
+-- user encouraged to use this call only from m0 thread.
+addM0Finalizer :: IO () -> IO ()
+addM0Finalizer f = atomicModifyIORef globalFinalizers (\x -> ((Nothing, f):x, ()))


### PR DESCRIPTION
*Created by: facundominguez*

Split from https://github.com/tweag/halon/pull/505
