### PR TITLE
Remove artifacts of GC metainfo being in RG

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero.hs
@@ -72,7 +72,6 @@ import Control.Wire hiding (when)
 import Data.Binary (Binary)
 import Data.Dynamic
 import qualified Data.Map.Strict as Map
-import qualified Data.HashSet as HS
 import qualified Data.Set as S
 import Data.UUID (UUID)
 


### PR DESCRIPTION
*Created by: Fuuzetsu*

These changes were part of an abandoned iteration for GC metainfo and
have made it to master even though they shouldn't have. This
effectively reverts those changes.
