### PR TITLE
Use existing EQ nodes if none specified for halonctl

### DIFF
--- a/halon/src/lib/HA/NodeUp.hs
+++ b/halon/src/lib/HA/NodeUp.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE TemplateHaskell            #-}
 
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
@@ -74,14 +75,34 @@ nodeUp :: ( [NodeId]
        -> Process ()
 nodeUp (eqs, _delay) = do
     self <- getSelfPid
-    fix $ \loop ->
-      whereis EQT.name >>= maybe (receiveTimeout 100000 [] >> loop)
-                                 (\ps -> do usend ps (self, EQT.UpdateEQNodes eqs)
-                                            mt <- expectTimeout 1000000
-                                            unless (mt == Just True) loop
-                                 )
-    say $ "Sending NodeUp message to " ++ show eqs ++ " me -> " ++ (show $ processNodeId self)
-    h <- liftIO $ getHostName
+
+    eqNodes <- case eqs of
+      -- We're trying to set the list of EQ nodes to []: that's not
+      -- good because then the promulgate will not complete under
+      -- normal circumstances. Instead of hoping that EQT will in the
+      -- future get updated by something and promulgate completes,
+      -- either send to existing EQ nodes (i.e. do nothing here) or
+      -- fail if no such nodes are known about.
+      [] -> withEQPid $ \retry ps -> do
+        usend ps $ EQT.ReplicaRequest self
+        expectTimeout 1000000 >>= \case
+          Nothing -> retry
+          Just (EQT.ReplicaReply (EQT.ReplicaLocation prefs eqns)) ->
+            if null eqns && null prefs
+            then fail "nodeUp: tried setting EQ nodes to [] with no replicas present"
+            else do
+              say "nodeUp: called with empty list of EQ nodes, using existing EQs instead"
+              return eqns
+      -- The list of requested eq nodes is not empty so we can safely
+      -- update it and then use promulgate.
+      eqs' -> withEQPid $ \retry ps -> do
+        usend ps (self, EQT.UpdateEQNodes eqs')
+        expectTimeout 1000000 >>= \case
+          Just True -> return eqs'
+          _ -> retry
+
+    say $ "Sending NodeUp message to " ++ show eqNodes ++ " me -> " ++ (show $ processNodeId self)
+    h <- liftIO getHostName
     _ <- promulgate $ NodeUp h self
     expect :: Process ()
     say "Node succesfully joined the cluster."
@@ -90,5 +111,11 @@ nodeUp (eqs, _delay) = do
        "nodeUp exception: " ++ show (e :: SomeException)
      say $ "nodeUp exception: " ++ show e
      liftIO $ throwIO e
+  where
+    withEQPid :: (Process a -> ProcessId -> Process a) -> Process a
+    withEQPid act = fix $ \loop ->
+      whereis EQT.name >>= maybe (receiveTimeout 100000 [] >> loop)
+                                 (act loop)
+
 
 remotable ['nodeUp]

--- a/mero-halon/src/halonctl/Handler/Bootstrap.hs
+++ b/mero-halon/src/halonctl/Handler/Bootstrap.hs
@@ -66,5 +66,5 @@ bootstrap :: [NodeId] -- ^ NodeIds of the node to bootstrap
           -> BootstrapCmdOptions
           -> Process ()
 bootstrap nids opts = case opts of
-  BootstrapNode naConf -> mapM_ (\nid -> S.start nid naConf) nids
-  BootstrapStation tsConf ->TS.start nids tsConf
+  BootstrapNode naConf -> mapM_ (flip S.start naConf) nids
+  BootstrapStation tsConf -> TS.start nids tsConf


### PR DESCRIPTION
*Created by: Fuuzetsu*

This is much saner than removing known EQ nodes and then having
promulgate wait for some node in the future to update the list of
nodes so it can send its message. Indeed, in case of `generateConf`,
there is a race condition on when the TS and SAT start: TS was
starting a bit after SAT, setting a meaningful value for EQ nodes
allowing SAT to proceed with `nodeUp`. Now the script should work no
matter of the order of events.
