### PR TITLE
Announce halonctl nodeUp loudly

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -231,7 +231,8 @@ Executable halonctl
                       options-schema >= 0.2,
                       optparse-applicative >= 0.11,
                       process,
-                      yaml
+                      yaml,
+                      mtl
   if flag(rpc)
       Build-Depends: network-transport-rpc >= 0.0.1
   else


### PR DESCRIPTION
*Created by: Fuuzetsu*

I chose to exitFailure as well because
1. It allows the user to test the exit code in a script if they so desire
2. No other process runs as part of halonctl after `nodeUp`s complete
3. User can `|| true` if they don't like the exit code
