### PR TITLE
Fixup `make rpm` for manual RPM generation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,10 +202,10 @@ check-freeze:
 # current checkout.
 # It will generate a binary RPM in ./rpmbuild/RPMS/x86_64
 # and a pseudo-source tar in ./rpmbuild/SRPMS
-rpm: build
+rpm:
 	mkdir -p rpmbuild/SOURCES
-	cp .cabal-sandbox/bin/halond rpmbuild/SOURCES/
-	cp .cabal-sandbox/bin/halonctl rpmbuild/SOURCES/
+	cp .stack-work/install/x86_64-linux/lts-3.11/7.10.2/bin/halond rpmbuild/SOURCES/
+	cp .stack-work/install/x86_64-linux/lts-3.11/7.10.2/bin/halonctl rpmbuild/SOURCES/
 	cp systemd/halond.service rpmbuild/SOURCES/
 	cp mero-halon/scripts/localcluster rpmbuild/SOURCES/halon-simplelocalcluster
 	rpmbuild --define "_topdir ${PWD}/rpmbuild" -ba rpmbuild/SPECS/halon-make.spec

--- a/rpmbuild/SPECS/halon-make.spec
+++ b/rpmbuild/SPECS/halon-make.spec
@@ -1,6 +1,6 @@
 Summary: halon
 Name: halon
-Version: 0.17
+Version: 0.20
 Release: 1
 License: All rights reserved
 Group: Development/Tools
@@ -44,4 +44,3 @@ rm -rf %{buildroot}
 /usr/local/bin/halonctl
 /usr/local/bin/halon-simplelocalcluster
 /usr/lib/systemd/system/halond.service
-


### PR DESCRIPTION
*Created by: nc6*

- Executables now taken from .stack-work directory.
- Increment version number.
