### PR TITLE
mero-halon: Fix disconnection tests built with mero.

### DIFF
--- a/mero-halon/tests/HA/Test/Disconnect.hs
+++ b/mero-halon/tests/HA/Test/Disconnect.hs
@@ -240,7 +240,7 @@ testRejoinTimeout _host baseTransport connectionBreak = withTmpDirectory $ do
 #ifdef USE_MERO
       let wait = void (expect :: Process ProcessMonitorNotification)
       promulgateEQ [localNodeId m1] (initialDataAddr _host _host 12) >>= (`withMonitor` wait)
-      "InitialLoad" :: String <- expect
+      receiveWait [ matchIf (("InitialLoad" :: String) ==) $ const $ return () ]
 #endif
 
       say $ "isolating TS node " ++ show (localNodeId <$> [m1])
@@ -302,7 +302,7 @@ testRejoinRCDeath _host baseTransport connectionBreak = withTmpDirectory $ do
 #ifdef USE_MERO
       let wait = void (expect :: Process ProcessMonitorNotification)
       promulgateEQ [localNodeId m1] (initialDataAddr _host _host 12) >>= (`withMonitor` wait)
-      "InitialLoad" :: String <- expect
+      receiveWait [ matchIf (("InitialLoad" :: String) ==) $ const $ return () ]
 #endif
 
       say $ "isolating TS node " ++ show (localNodeId <$> [m1])
@@ -372,7 +372,7 @@ testRejoin _host baseTransport connectionBreak = withTmpDirectory $ do
 #ifdef USE_MERO
       let wait = void (expect :: Process ProcessMonitorNotification)
       promulgateEQ [localNodeId m1] (initialDataAddr _host _host 12) >>= (`withMonitor` wait)
-      "InitialLoad" :: String <- expect
+      receiveWait [ matchIf (("InitialLoad" :: String) ==) $ const $ return () ]
 #endif
 
       say $ "isolating TS node " ++ show (localNodeId <$> [m1])


### PR DESCRIPTION
*Created by: facundominguez*

With this, tests pass for me. It seems "NewNode" messages are produced more than once, and this surprises the conditionally compiled `"InitialLoad" <- expect`.

@Fuuzetsu, is `NewNode` supposed to be produced more than once?

Without this patch, the failure can be reproduced with the parent commit and

```
DP_SCHEDULER_SEED=-3712625722573313241 TEST_LISTEN=10.0.2.15:0 HALON_BUILD_ENV=bare MERO_ROOT=/home/vagrant/halon/vendor/mero LD_LIBRARY_PATH=/home/vagrant/halon/vendor/mero/mero/.libs ./hack build --test mero-halon:scheduler-tests --test-arguments "-p testRejoin"
```
