### PR TITLE
mero-halon: allow support different object types mapped to the same Fid type

### DIFF
--- a/mero-halon/src/lib/HA/Resources/Mero.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero.hs
@@ -41,7 +41,9 @@ import qualified "distributed-process-scheduler" System.Clock as C
 
 import Control.Arrow ((***))
 import Data.List (nub)
-import Data.Maybe (listToMaybe)
+import Data.Maybe (listToMaybe, fromMaybe)
+import qualified Data.Map as Map
+import Data.Monoid
 import qualified HA.ResourceGraph as G
 import Mero.ConfC ( ServiceType(..) )
 --------------------------------------------------------------------------------
@@ -475,8 +477,12 @@ data SomeConfObjDict = forall x. (Typeable x, ConfObj x) =>
 -- Yields the ConfObj dictionary of the object with the given Fid.
 --
 -- TODO: Generate this with TH.
-fidConfObjDict :: Fid -> Maybe SomeConfObjDict
-fidConfObjDict f = lookup (f_container f `shiftR` (64 - 8))
+fidConfObjDict :: Fid -> [SomeConfObjDict]
+fidConfObjDict f = fromMaybe [] $ Map.lookup (f_container f `shiftR` (64 - 8)) dictMap
+
+-- | Map of all dictionaries
+dictMap :: Map.Map Word64 [SomeConfObjDict]
+dictMap = Map.fromListWith (<>)
     [ mkTypePair (Proxy :: Proxy Root)
     , mkTypePair (Proxy :: Proxy Profile)
     , mkTypePair (Proxy :: Proxy Filesystem)
@@ -497,8 +503,8 @@ fidConfObjDict f = lookup (f_container f `shiftR` (64 - 8))
     ]
   where
     mkTypePair :: forall a. (Typeable a, ConfObj a)
-               => Proxy a -> (Word64, SomeConfObjDict)
-    mkTypePair a = (fidType a, SomeConfObjDict (Proxy :: Proxy a))
+               => Proxy a -> (Word64, [SomeConfObjDict])
+    mkTypePair a = (fidType a, [SomeConfObjDict (Proxy :: Proxy a)])
 
 -- | Get all 'M0.Service' running on the 'Cluster', starting at
 -- 'M0.Profile's.

--- a/mero-halon/src/lib/HA/Resources/Mero/Note.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero/Note.hs
@@ -90,7 +90,7 @@ rgLookupConfObjectStates fids g =
     , state : _   <- [(catMaybes $ map findConfObjectState rels)++[M0_NC_ONLINE]]
     ]
   where
-    fidDicts = nubBy sameDicts $ catMaybes $ map M0.fidConfObjDict fids
+    fidDicts = nubBy sameDicts $ concat $ map M0.fidConfObjDict fids
     sameDicts (M0.SomeConfObjDict (_ :: Proxy ct0))
               (M0.SomeConfObjDict (_ :: Proxy ct1)) =
       isJust (eqT :: Maybe (ct0 :~: ct1))


### PR DESCRIPTION
*Created by: qnikst*

All version types in confd have same type 'j' (0x6a), this patch
allow halon to query object of any type that have same Fid tyoe
