### PR TITLE
mero-halon: fix frontier service.

### DIFF
--- a/mero-halon/src/lib/HA/Services/Frontier/CEP.hs
+++ b/mero-halon/src/lib/HA/Services/Frontier/CEP.hs
@@ -53,12 +53,14 @@ ruleDumpKeyValues = defineSimple "frontiner-get-key-values" $
 -- This call marked as proccessed immediately and is not reprocessed if case
 -- of RC failure.
 ruleDumpGraph :: Definitions LoopState ()
-ruleDumpGraph = defineSimple "fontiner-dump-graph" $ 
+ruleDumpGraph = defineSimple "frontier-dump-graph" $ 
   \(HAEvent uuid (ReadResourceGraph, pid) _) -> do
       rg   <- getLocalGraph
       _ <- liftProcess $ spawnLocal $ do
              let reply = dumpGraph $ G.getGraphResources rg
+             say "start sending graph"
              mapM_ (usend pid) $ BL.toChunks 
                                $ toLazyByteString . lazyByteString $ reply
              usend pid ()
+             say "finished sending graph"
       messageProcessed uuid


### PR DESCRIPTION
*Created by: qnikst*

- Frontier service was not closing it's socket, so it was not possible
  to use that socket even service was stopped.
- Fix types of the messages beign received.
