### PR TITLE
Remove messages from the EQ in more places, mainly tests

### DIFF
--- a/mero-halon/src/lib/HA/Services/Mero/CEP.hs
+++ b/mero-halon/src/lib/HA/Services/Mero/CEP.hs
@@ -54,5 +54,6 @@ meroChannels m0d rg = [ chan | node <- connectedTo Cluster Has rg
 meroRulesF :: Service MeroConf -> Definitions LoopState ()
 meroRulesF _ = do
   defineSimple "declare-mero-channel" $
-    \(HAEvent _ (DeclareMeroChannel sp c) _) -> do
+    \(HAEvent eid (DeclareMeroChannel sp c) _) -> do
       registerChannel sp c
+      messageProcessed eid

--- a/mero-halon/tests/HA/Castor/Story/Tests.hs
+++ b/mero-halon/tests/HA/Castor/Story/Tests.hs
@@ -20,6 +20,7 @@ import HA.RecoveryCoordinator.Actions.Mero.Failure.Dynamic
    , findFailableObjs
    )
 #endif
+import HA.RecoveryCoordinator.Actions.Core (messageProcessed)
 import HA.RecoveryCoordinator.Actions.Service
   ( registerServiceProcess )
 import HA.RecoveryCoordinator.Events.Drive
@@ -102,7 +103,7 @@ newMeroChannel pid = do
 testRules :: Definitions LoopState ()
 testRules = do
   defineSimple "register-mock-service" $
-    \(HAEvent _ (MockM0 dc@(DeclareMeroChannel sp _)) _) -> do
+    \(HAEvent eid (MockM0 dc@(DeclareMeroChannel sp _)) _) -> do
       nid <- liftProcess $ getSelfNode
       liftProcess $ say "here-1"
       registerServiceProcess (Node nid) m0d mockMeroConf sp
@@ -110,6 +111,7 @@ testRules = do
       void . liftProcess $ promulgateEQ [nid] dc
       liftProcess $ say "here-3"
       phaseLog "debug" "here am i"
+      messageProcessed eid
 
 mkTests :: IO (Transport -> [TestTree])
 mkTests = do

--- a/mero-halon/tests/HA/RecoveryCoordinator/Tests.hs
+++ b/mero-halon/tests/HA/RecoveryCoordinator/Tests.hs
@@ -237,13 +237,15 @@ testClusterStatus transport = runDefaultTest transport $ do
   where
     wait = void (expect :: Process ProcessMonitorNotification)
     clusterStatusRules :: [Definitions LoopState ()]
-    clusterStatusRules = return $ defineSimple "cluster-status" $ \(HAEvent _ cmsg _) -> case cmsg of
+    clusterStatusRules = return $ defineSimple "cluster-status" $ \(HAEvent eid cmsg _) -> case cmsg of
         ClusterGet -> do
           cs <- getClusterStatus
           liftProcess . say $ "Cluster status is " ++ show cs
+          messageProcessed eid
         ClusterSet cs -> do
           setClusterStatus cs
           liftProcess . say $ "Set cluster status to " ++ show cs
+          messageProcessed eid
 
 -- | Tests decision-log service by starting it and redirecting the logs to own
 --  process, then starting a dummy service and checking that logs were


### PR DESCRIPTION
*Created by: Fuuzetsu*

In general we don't seem to be leaking messages anywhere, at least on
a noticable scale. We may want to consider some kind of reporting such
as checking if the EQ is bigger than some given N, with N of 50 or so,
at least for now.
