### PR TITLE
mero-halon: Fix service restart procedure.

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Mero/Conf.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Mero/Conf.hs
@@ -238,21 +238,6 @@ enclosureOnline = promulgateRC . stateChange (Proxy :: Proxy 'M0.M0_NC_ONLINE)
 -- Helpers
 -------------------------------------------------------------------------------
 
--- | Run action iff entity is not in the online state.
-whenNotOnline :: G.Relation R.Is a M0.ConfObjectState
-              => a -> PhaseM LoopState l () -> PhaseM LoopState l ()
-whenNotOnline = whenNotState M0.M0_NC_ONLINE
-
--- | Run action iff entity is not in the transient state.
-whenNotTransient :: G.Relation R.Is a M0.ConfObjectState
-              => a -> PhaseM LoopState l () -> PhaseM LoopState l ()
-whenNotTransient = whenNotState M0.M0_NC_TRANSIENT
-
--- | Run action iff entity is not in the failed state.
-whenNotFailed :: G.Relation R.Is a M0.ConfObjectState
-              => a -> PhaseM LoopState l () -> PhaseM LoopState l ()
-whenNotFailed = whenNotState M0.M0_NC_FAILED
-
 -- | Run action iff entity is not in given state.
 whenNotState :: G.Relation R.Is a M0.ConfObjectState
               => M0.ConfObjectState -> a -> PhaseM LoopState l () -> PhaseM LoopState l ()
@@ -280,7 +265,7 @@ onStateChange :: (M0.ConfObj b, Show b, Serializable a, G.Relation R.Is b M0.Con
               -> (a -> b)           -- ^ Extract object from message.
               -> (forall l . [b -> PhaseM LoopState l ()]) -- ^ List of actions
               -> Specification LoopState ()
-onStateChange name st get actions = defineSimpleTask name $ \(HAEvent _ (get -> entity) _) ->
+onStateChange name st getE actions = defineSimpleTask name $ \(HAEvent _ (getE -> entity) _) ->
    whenNotState st entity $ do
      phaseLog "conf-obj" $ show entity ++ " becomes " ++ show st
      sequence_ $ map ($ entity) actions

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Service.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Service.hs
@@ -15,6 +15,7 @@ module HA.RecoveryCoordinator.Rules.Service where
 
 import Prelude hiding ((.), id)
 import Control.Category
+import Data.Foldable (traverse_)
 
 import           Control.Distributed.Process
 import           Control.Distributed.Process.Closure (mkClosure)
@@ -343,3 +344,7 @@ serviceRules argv = do
           _ -> SrvStatError $ "Wrong config profiles found."
     liftProcess $ mapM_ (flip usend (encodeP response)) listeners
     messageProcessed uuid
+
+  defineSimpleTask "service-stopped" $ \(HAEvent _ msg _) -> do
+    ServiceExit node svc@(Service{}) _ <- decodeMsg msg
+    traverse_  (unregisterServiceProcess node svc) =<< lookupRunningService node svc 


### PR DESCRIPTION
*Created by: qnikst*

When service was stopped by user no information was received on
RC, so RG had information that service is running. As a result it
was not possible to start service once again. This commit fixes
this situation by sending message to RC in case of normal service
exit.
