### PR TITLE
mero-halon: fix double rconf stop.

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Spiel.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Spiel.hs
@@ -118,7 +118,6 @@ withRConfRC spiel action = do
      Mero.Spiel.rconfStart spiel
      Mero.Spiel.setCmdProfile spiel (fmap (\(M0.Profile p) -> show p) mp)
   x <- action `sfinally` liftM0RC (Mero.Spiel.rconfStop spiel)
-  liftM0RC $ Mero.Spiel.rconfStop spiel
   return x
 
 -- | Start the repair operation on the given 'M0.Pool'. Notifies mero


### PR DESCRIPTION
*Created by: qnikst*

Fix a double rconf stop.
