### PR TITLE
mero-halon: fix operation safety.

### DIFF
--- a/mero-halon/src/lib/Mero/Notification/HAState.hsc
+++ b/mero-halon/src/lib/Mero/Notification/HAState.hsc
@@ -217,11 +217,11 @@ notify se (RPCAddress rpcAddr) nvec timeout_s =
       ha_state_notify (se_ptr se) caddr (NVecRef pnvec) (fromIntegral timeout_s)
         >>= check_rc "notify"
 
-foreign import ccall unsafe ha_state_notify :: Ptr ClientEndpointV
-                                            -> CString
-                                            -> NVecRef
-                                            -> CInt
-                                            -> IO CInt
+foreign import ccall ha_state_notify :: Ptr ClientEndpointV
+                                     -> CString
+                                     -> NVecRef
+                                     -> CInt
+                                     -> IO CInt
 
 -- | Type of exceptions that HAState calls can produce.
 data HAStateException = HAStateException String Int


### PR DESCRIPTION
*Created by: qnikst*

notify mero is potentially blocking operation, so it could not
be marked as unsafe.
