### PR TITLE
mero-halon: fix long recovery process

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/SpielQuery.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/SpielQuery.hs
@@ -97,7 +97,7 @@ queryStartHandling pool prt = do
      -- This is the first of many notifications, start query in 5
      -- minutes.
      | priOnlineNotifications pri == 1 && iosvs > 1 ->
-         selfMessage $ SpielQuery pool prt
+         promulgateRC $ SpielQuery pool prt
      -- This is not the first notification so we have already
      -- dispatched a query before, do nothing.
      | otherwise -> return ()


### PR DESCRIPTION
*Created by: qnikst*

Long pool repair query was waiting for HAEvent, but plain event was
sent to it.

Conflicts:
    mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/SpielQuery.hs
