### PR TITLE
Provide API for deferred initialization of all required FOPs.

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -146,6 +146,7 @@ Library
 
   if flag(mero)
       Exposed-Modules: Mero.Epoch
+                       Mero.Environment
                        Mero.M0Worker
                        Mero.Notification
                        Mero.Notification.HAState

--- a/mero-halon/src/halond/Main.hs
+++ b/mero-halon/src/halond/Main.hs
@@ -28,6 +28,7 @@ import Control.Distributed.Static ( closureCompose )
 
 #ifdef USE_MERO
 import Mero
+import Mero.Environment
 import Mero.Notification (initialize_pre_m0_init)
 #endif
 import System.Environment
@@ -50,7 +51,7 @@ myRemoteTable = haRemoteTable $ meroRemoteTable initRemoteTable
 
 main :: IO ()
 #ifdef USE_MERO
-main = withM0Deferred $ mdo
+main = withM0Deferred initializeFOPs deinitializeFOPs $ mdo
     initialize_pre_m0_init lnid
 #else
 main = do

--- a/mero-halon/src/lib/Mero/Environment.hs
+++ b/mero-halon/src/lib/Mero/Environment.hs
@@ -1,0 +1,30 @@
+-- |
+-- Module: Mero.Environment
+-- Copyright: (C) 2015 Seagate Technology Limited.
+{-# LANGUAGE ForeignFunctionInterface #-}
+module Mero.Environment 
+  ( initializeFOPs
+  , deinitializeFOPs
+  ) where
+
+initializeFOPs :: IO ()
+initializeFOPs = do
+  c_m0_sns_cm_repair_trigger_fop_init
+  c_m0_sns_cm_rebalance_trigger_fop_init
+
+deinitializeFOPs :: IO ()
+deinitializeFOPs = do
+  c_m0_sns_cm_rebalance_trigger_fop_init
+  c_m0_sns_cm_repair_trigger_fop_init
+
+foreign import ccall "cm/cm.h m0_sns_cm_repair_trigger_fop_init"
+  c_m0_sns_cm_repair_trigger_fop_init :: IO ()
+
+foreign import ccall "cm/cm.h m0_sns_cm_rebalance_trigger_fop_init"
+  c_m0_sns_cm_rebalance_trigger_fop_init :: IO ()
+
+foreign import ccall "cm/cm.h m0_sns_cm_repair_trigger_fop_fini"
+  c_m0_sns_cm_repair_trigger_fop_fini :: IO ()
+
+foreign import ccall "cm/cm.h m0_sns_cm_rebalance_trigger_fop_fini"
+  c_m0_sns_cm_rebalance_trigger_fop_fini :: IO ()

--- a/mero-halon/tests/tests-mero-integration.hs
+++ b/mero-halon/tests/tests-mero-integration.hs
@@ -7,6 +7,7 @@ module Main
   ( main ) where
 
 import Mero
+import Mero.Environment
 import qualified HA.Castor.Story.Tests
 import qualified HA.RecoveryCoordinator.Mero.Tests
 
@@ -38,12 +39,12 @@ main = withMeroEnvironment router wrapper where
     case minfo of
       Just ("RCSyncToConfd", host) -> do
         transport <- mkTransport
-        return $ Just $ withM0Deferred $ do
+        return $ Just $ withM0Deferred initializeFOPs deinitializeFOPs $ do
           HA.RecoveryCoordinator.Mero.Tests.testRCsyncToConfd host transport
           threadDelay 1000000
       Just ("DriveFailurePVer", _host) -> do
         transport <- mkTransport
-        return $ Just $ withM0Deferred $ do
+        return $ Just $ withM0Deferred initializeFOPs deinitializeFOPs $ do
           HA.Castor.Story.Tests.testDynamicPVer transport
           threadDelay 1000000
       _ -> return Nothing


### PR DESCRIPTION
*Created by: qnikst*

withM0Deferred type was changed so there is a way to pass
additional initialization functionst that should be running right
after m0_init.
