### PR TITLE
Use boot_level to control booting.

### DIFF
--- a/mero-halon/scripts/mero_provisioner_role_mappings.ede
+++ b/mero-halon/scripts/mero_provisioner_role_mappings.ede
@@ -1,3 +1,30 @@
+- name: "ha"
+  content:
+    - m0p_endpoint: "{{ lnid }}:12345:34:101"
+      m0p_mem_as: {{ host_mem }}
+      m0p_mem_rss: {{ host_mem_rss }}
+      m0p_mem_stack: {{ host_mem_stack }}
+      m0p_mem_memlock: {{ host_mem_memlock }}
+      m0p_cores:
+{% for core in host_cores %}
+       - {{ core.value }}
+{% endfor %}
+      m0p_boot_level: -1
+      m0p_services:
+        - m0s_type:
+            tag: CST_MGS
+            contents: []
+          m0s_endpoints: ["{{ lnid }}:12345:34:101"]
+          m0s_params:
+            tag: SPConfDBPath
+            contents: "/var/mero/confd"
+        - m0s_type:
+            tag: CST_RMS
+            contents: []
+          m0s_endpoints: ["{{ lnid }}:12345:34:101"]
+          m0s_params:
+            tag: SPUnused
+            contents: []
 - name: "confd"
   content:
     - m0p_endpoint: "{{ lnid }}:12345:44:101"
@@ -9,7 +36,7 @@
 {% for core in host_cores %}
        - {{ core.value }}
 {% endfor %}
-      m0p_boot_level: 1
+      m0p_boot_level: 0
       m0p_services:
         - m0s_type:
             tag: CST_MGS
@@ -21,20 +48,13 @@
         - m0s_type:
             tag: CST_RMS
             contents: []
-          m0s_endpoints: ["{{ lnid }}:12345:43:301"]
-          m0s_params:
-            tag: SPUnused
-            contents: []
-        - m0s_type:
-            tag: CST_HA
-            contents: []
-          m0s_endpoints: ["{{ lnid }}:12345:34:101"]
+          m0s_endpoints: ["{{ lnid }}:12345:44:101"]
           m0s_params:
             tag: SPUnused
             contents: []
 - name: "mds"
   content:
-    - m0p_endpoint: "{{ lnid }}:12345:41:101"
+    - m0p_endpoint: "{{ lnid }}:12345:41:201"
       m0p_mem_as: {{ host_mem }}
       m0p_mem_rss: {{ host_mem_rss }}
       m0p_mem_stack: {{ host_mem_stack }}
@@ -48,7 +68,7 @@
         - m0s_type:
             tag: CST_RMS
             contents: []
-          m0s_endpoints: ["{{ lnid }}:12345:41:301"]
+          m0s_endpoints: ["{{ lnid }}:12345:41:201"]
           m0s_params:
             tag: SPUnused
             contents: []
@@ -56,27 +76,6 @@
             tag: CST_MDS
             contents: []
           m0s_endpoints: ["{{ lnid }}:12345:41:201"]
-          m0s_params:
-            tag: SPUnused
-            contents: []
-        - m0s_type:
-            tag: CST_IOS
-            contents: []
-          m0s_endpoints: ["{{ lnid }}:12345:41:401"]
-          m0s_params:
-            tag: SPUnused
-            contents: []
-        - m0s_type:
-            tag: CST_SNS_REP
-            contents: []
-          m0s_endpoints: ["{{ lnid }}:12345:41:401"]
-          m0s_params:
-            tag: SPUnused
-            contents: []
-        - m0s_type:
-            tag: CST_SNS_REB
-            contents: []
-          m0s_endpoints: ["{{ lnid }}:12345:41:401"]
           m0s_params:
             tag: SPUnused
             contents: []
@@ -96,7 +95,7 @@
         - m0s_type:
             tag: CST_RMS
             contents: []
-          m0s_endpoints: ["{{ lnid }}:12345:41:301"]
+          m0s_endpoints: ["{{ lnid }}:12345:41:401"]
           m0s_params:
             tag: SPUnused
             contents: []

--- a/mero-halon/scripts/mero_role_mappings.ede
+++ b/mero-halon/scripts/mero_role_mappings.ede
@@ -9,7 +9,7 @@
 {% for core in host_cores %}
        - {{ core.value }}
 {% endfor %}
-      m0p_boot_level: 1
+      m0p_boot_level: 0
       m0p_services:
         - m0s_type:
             tag: CST_MGS
@@ -81,7 +81,7 @@
 {% for core in host_cores %}
        - {{ core.value }}
 {% endfor %}
-      m0p_boot_level: 1
+      m0p_boot_level: -1
       m0p_services:
       - m0s_type:
           tag: CST_HA

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Conf.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Conf.hs
@@ -182,9 +182,9 @@ loadMeroServers fs = mapM_ goHost . offsetHosts where
                               m0p_mem_stack m0p_mem_memlock
                               cores m0p_endpoint
       procLabel = if
-          elem CST_MGS $ fmap CI.m0s_type m0p_services
-        then M0.PLConfdBoot
-        else M0.PLRegularBoot
+          m0p_boot_level < 0
+        then M0.PLNoBoot
+        else M0.PLBootLevel (fromIntegral m0p_boot_level)
     in do
       proc <- mkProc <$> newFidRC (Proxy :: Proxy M0.Process)
       mapM_ (goSrv proc devs) m0p_services

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor.hs
@@ -612,7 +612,7 @@ ruleNewMeroClient = define "new-mero-client" $ do
       mhost <- findNodeHost node
       case (,) <$> mhost <*> (m0svc >>= meroChannel rg) of
         Just (host, chan) -> do
-          startNodeProcesses host chan PLConfdBoot True
+          startNodeProcesses host chan (PLBootLevel 0) True
         Nothing -> switch [svc_up_now, timeout 5000000 svc_up_already]
 
     setPhase msgClientNodeBootstrapped $ \(HAEvent eid (ProcessControlResultMsg node _) _) -> do

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Server.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Server.hs
@@ -151,7 +151,7 @@ ruleNewMeroServer = define "new-mero-server" $ do
   setPhaseIf svc_up_now onNode $ \(host, chan) -> do
     -- Legitimate to avoid the event id as it should be handled by the default
     -- 'declare-mero-channel' rule.
-    startNodeProcesses host chan PLConfdBoot True
+    startNodeProcesses host chan (PLBootLevel 0) True
     continue core_bootstrapped
 
   -- Service is already up
@@ -162,7 +162,7 @@ ruleNewMeroServer = define "new-mero-server" $ do
     mhost <- findNodeHost node
     case (,) <$> mhost <*> (m0svc >>= meroChannel rg) of
       Just (host, chan) -> do
-        startNodeProcesses host chan PLConfdBoot True
+        startNodeProcesses host chan (PLBootLevel 0) True
         continue core_bootstrapped
       Nothing -> switch [svc_up_now, timeout 5000000 finish]
 
@@ -195,7 +195,7 @@ ruleNewMeroServer = define "new-mero-server" $ do
            mhost <- findNodeHost (Node nid)
            case (,) <$> mhost <*> (m0svc >>= meroChannel g) of
              Just (host, chan) -> do
-               startNodeProcesses host chan PLRegularBoot True
+               startNodeProcesses host chan (PLBootLevel 1) True
                continue finish_extra_bootstrap
              Nothing -> do
                phaseLog "error" $ "Can't find host for node " ++ show node

--- a/mero-halon/src/lib/HA/Resources/Mero.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero.hs
@@ -387,8 +387,8 @@ instance Hashable HostHardwareInfo
 --   it should run.
 data ProcessLabel =
     PLM0t1fs -- ^ Process lives as part of m0t1fs in kernel space
-  | PLConfdBoot -- ^ Process which should be started as part of confd boot
-  | PLRegularBoot -- ^ Processes which should be started as part of regular boot
+  | PLBootLevel Int -- ^ Process boot level. Currently 0 = confd, 1 = other0
+  | PLNoBoot  -- ^ Tag processes which should not boot.
   deriving (Eq, Show, Typeable, Generic)
 instance Binary ProcessLabel
 instance Hashable ProcessLabel


### PR DESCRIPTION
*Created by: nc6*

Now we have the ability to specify boot level for a process,
we can use this directly to control the boot sequence, rather
than just looking for the presence of the MGS service.

In addition, this commit alters service mappings to add in an
'ha' role, which sounds like it will be needed on all machines.
