### PR TITLE
mero-halon: SSPL service should not fail on unknown SSPL replies.

### DIFF
--- a/mero-halon/src/lib/HA/Services/SSPL.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL.hs
@@ -209,12 +209,15 @@ startActuators chan ac pid = do
                    . actuatorResponseMessageActuator_response_type
                    . actuatorResponseMessage $ response
           -- XXX: uuid-1.3.10 has UID.fromText primitive
-          ppid <- promulgate $ CommandAck (UID.fromString =<< T.unpack <$> uuid)
-                                          (parseNodeCmd  mtype)
-                                          (parseAckReply mmsg)
-          ProcessMonitorNotification _ _ _ <-
-            withMonitor ppid $ expect
-          return ())
+          case tryParseAckReply mmsg of
+            Left t -> saySSPL $ "Failed to parse SSPL reply: " ++ T.unpack mmsg
+            Right reply -> do
+               ppid <- promulgate $ CommandAck (UID.fromString =<< T.unpack <$> uuid)
+                                               (parseNodeCmd  mtype)
+                                               reply
+               ProcessMonitorNotification _ _ _ <-
+                 withMonitor ppid $ expect
+               return ())
 
 remotableDecl [ [d|
 

--- a/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
@@ -142,13 +142,13 @@ data AckReply = AckReplyPassed       -- ^ Request succesfully processed.
 instance Binary AckReply
 
 -- | Parse text representation of the @AckReply@
-parseAckReply :: T.Text -> AckReply
-parseAckReply "Passed" = AckReplyPassed
-parseAckReply "Failed" = AckReplyFailed
-parseAckReply t
-  | errmsg `T.isPrefixOf` t = AckReplyError $ T.drop (T.length errmsg) t
-  | success `T.isPrefixOf` t = AckReplyPassed
-  | otherwise               = error $ "parseAckReply: unknown reply (" ++ T.unpack t ++ ")"
+tryParseAckReply :: T.Text -> Either String AckReply
+tryParseAckReply "Passed" = Right AckReplyPassed
+tryParseAckReply "Failed" = Right AckReplyFailed
+tryParseAckReply t
+  | errmsg `T.isPrefixOf` t = Right $ AckReplyError $ T.drop (T.length errmsg) t
+  | success `T.isPrefixOf` t = Right AckReplyPassed
+  | otherwise               = Left $ "parseAckReply: unknown reply (" ++ T.unpack t ++ ")"
   where errmsg = "Error: "
         success = "Success"
 


### PR DESCRIPTION
*Created by: qnikst*

SSPL awaits for messages with fixed structure in SSPL ack channel.
However this messages are not yet structured. So instead of loud
failure, halon will ignore problematic messages and will output
logs about that.
