### PR TITLE
HALON-134: Update SSPL notification about drive failure.

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Hardware.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Hardware.hs
@@ -68,7 +68,6 @@ module HA.RecoveryCoordinator.Actions.Hardware
   , markOnGoingReset
   , markResetComplete
   , markStorageDeviceRemoved
-  , updateDriveManagerWithFailure
   , unmarkStorageDeviceRemoved
     -- ** Drive candidates
   , attachStorageDeviceReplacement
@@ -91,18 +90,11 @@ import qualified HA.Resources.Mero as M0
 #endif
 
 import Control.Category ((>>>))
-import Control.Distributed.Process (liftIO, say)
-import Control.Monad.Catch (catch)
+import Control.Distributed.Process (liftIO)
 
-import qualified Data.Aeson as A
-import qualified Data.Aeson.Types as A
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BSL
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.UUID.V4 (nextRandom)
 import Data.Foldable
-import GHC.Generics (Generic)
 
 import Network.CEP
 
@@ -793,77 +785,3 @@ setDiskPowerOffAttempts sdev i = do
       setStorageDeviceAttr sdev (SDPowerOffAttempts i)
     _ -> setStorageDeviceAttr sdev (SDPowerOffAttempts i)
 
--- | Drive information structure used by DCS drive manager.
-data DMSDrive = DMSDrive
-  { _dmsd_reason :: String
-  , _dmsd_serial_number :: String
-  , _dmsd_status :: String
-  } deriving (Show, Eq, Generic)
-
-dmsDriveJSONOptions :: A.Options
-dmsDriveJSONOptions = A.defaultOptions
-  { A.fieldLabelModifier = drop (length ("_dmsd_" :: String)) }
-
-instance A.FromJSON DMSDrive where
-  parseJSON = A.genericParseJSON dmsDriveJSONOptions
-
-instance A.ToJSON DMSDrive where
-  toJSON = A.genericToJSON dmsDriveJSONOptions
-
--- | The structured storing information about status of drives, used by DCS
--- drive manager.
-data DriveManagerStatus = DriveManagerStatus
-  { _dms_drive_manager_version :: Int
-  , _dms_drives :: [DMSDrive]
-  , _dms_format_version :: Int
-  , _dms_last_update_time :: String
-  } deriving (Show, Eq, Generic)
-
-dmsJSONOptions :: A.Options
-dmsJSONOptions = A.defaultOptions
-  { A.fieldLabelModifier = drop (length ("_dms_" :: String)) }
-
-instance A.FromJSON DriveManagerStatus where
-  parseJSON = A.genericParseJSON dmsJSONOptions
-
-instance A.ToJSON DriveManagerStatus where
-  toJSON = A.genericToJSON dmsJSONOptions
-
--- | Mark given the given 'StorageDevice' as failed in
--- @/tmp/dcs/drivemanager/drive_manager.json@ so the DCS drive manager
--- plugin can update the filesystem. An alternative file path can be
--- passed in.
-updateDriveManagerWithFailure :: forall l. Maybe FilePath
-                              -> StorageDevice
-                              -> PhaseM LoopState l ()
-updateDriveManagerWithFailure fp disk = flip catch ioHandler $ do
-  dis <- findStorageDeviceIdentifiers disk
-  case listToMaybe [ sn' | DISerialNumber sn' <- dis ] of
-    Nothing -> sayDM $ "Unable to find serial number for " ++ show disk
-    Just sn -> do
-      dmf <- liftIO $ BS.readFile dmFile
-      case A.eitherDecodeStrict dmf of
-        Left msg -> sayDM $ "Failed to parse drive_manager.json: " ++ show msg
-        Right dms -> do
-          t :: Int <- liftIO $ floor <$> getPOSIXTime
-          let dms' = dms { _dms_drives = map (setFailed sn) $ _dms_drives dms
-                         , _dms_last_update_time = show t }
-          liftIO . BSL.writeFile dmFile $ A.encode dms'
-          sayDM "drive_manager.json updated successfully"
-  where
-    sayDM = liftProcess . say . ("updateDriveManagerWithFailure: " ++)
-
-    dmFile :: FilePath
-    dmFile = fromMaybe "/tmp/dcs/drivemanager/drive_manager.json" fp
-    -- Do we need to handle the ‘if the drive is subsequently powered
-    -- down’ case somehow?
-    setFailed :: String -> DMSDrive -> DMSDrive
-    setFailed sn d = if _dmsd_serial_number d == sn
-                     then d { _dmsd_status = "Failed" }
-                     else d
-
-    -- We might fail to read/write the drive manager file for whatever
-    -- reason. Maybe depending on the type of failure we should do
-    -- something more sensible.
-    ioHandler :: IOError -> PhaseM LoopState l ()
-    ioHandler e = sayDM $ "Received IOError: " ++ show e

--- a/mero-halon/src/lib/HA/Services/SSPL.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL.hs
@@ -210,7 +210,7 @@ startActuators chan ac pid = do
                    . actuatorResponseMessage $ response
           -- XXX: uuid-1.3.10 has UID.fromText primitive
           case tryParseAckReply mmsg of
-            Left t -> saySSPL $ "Failed to parse SSPL reply: " ++ T.unpack mmsg
+            Left _ -> saySSPL $ "Failed to parse SSPL reply: " ++ T.unpack mmsg
             Right reply -> do
                ppid <- promulgate $ CommandAck (UID.fromString =<< T.unpack <$> uuid)
                                                (parseNodeCmd  mtype)

--- a/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
@@ -20,6 +20,7 @@ import SSPL.Bindings
   ( ActuatorRequestMessageActuator_request_type (..)
   , ActuatorRequestMessageActuator_request_typeService_controller (..)
   , ActuatorRequestMessageActuator_request_typeNode_controller (..)
+  , ActuatorRequestMessageActuator_request_typeLogging (..)
   )
 
 import Control.Applicative ((<$>), (<*>))
@@ -133,6 +134,12 @@ parseNodeCmd t =
   where
     (cmd:rest) = T.words t
 
+data LoggerCmd = LoggerCmd 
+       { lcMsg :: T.Text
+       , lcLevel :: T.Text
+       , lcType  :: T.Text
+       } deriving (Eq, Show, Generic, Typeable)
+
 -- | Actuator reply.
 data AckReply = AckReplyPassed       -- ^ Request succesfully processed.
               | AckReplyFailed       -- ^ Request failed.
@@ -183,6 +190,17 @@ makeNodeMsg nc = emptyActuatorMsg {
     ActuatorRequestMessageActuator_request_typeNode_controller
       (nodeCmdString nc)
 }
+
+makeLoggerMsg :: LoggerCmd -> ActuatorRequestMessageActuator_request_type
+makeLoggerMsg lc = emptyActuatorMsg {
+  actuatorRequestMessageActuator_request_typeLogging = Just $
+    ActuatorRequestMessageActuator_request_typeLogging
+      { actuatorRequestMessageActuator_request_typeLoggingLog_msg = lcMsg lc
+      , actuatorRequestMessageActuator_request_typeLoggingLog_level = Just (lcLevel lc)
+      , actuatorRequestMessageActuator_request_typeLoggingLog_type = lcType lc
+      }
+  }
+   
 --------------------------------------------------------------------------------
 -- Channels                                                                   --
 --------------------------------------------------------------------------------


### PR DESCRIPTION
*Created by: qnikst*

Notification about drive failure should go via logger actuator
in SSPL. This commit changes behaviour to support that way of
notification. So now it's not halon responcibility to update
information in dcs filesystem, but RAS/sspl one.

Changes:
- New actuator request type was intoduced
- Halon fixed a way of notification now node where event happens is
  notified, on the contrary to the previous case when everything
  happened on node keeping RC
- makeLoggerCmd api for creation logger commands was introduced

Current logger commands are not structurized and there is no schema
for them, this will be done in future.
