### PR TITLE
HALON-149: notify new SSPL instance about failed devices.

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -508,6 +508,7 @@ Test-Suite unit-tests
                     mero-halon,
                     base >= 4.5,
                     binary >= 0.6.4,
+                    aeson,
                     bytestring,
                     directory,
                     distributed-process-scheduler,
@@ -589,6 +590,7 @@ Test-Suite integration-tests
                       ScopedTypeVariables
   Build-Depends:    halon,
                     mero-halon,
+                    aeson,
                     base >= 4.5,
                     binary >= 0.6.4,
                     bytestring,
@@ -668,6 +670,7 @@ Test-Suite scheduler-tests
                       ScopedTypeVariables
   Build-Depends:    halon,
                     mero-halon,
+                    aeson,
                     base >= 4.5,
                     binary >= 0.6.4,
                     bytestring,
@@ -850,6 +853,7 @@ Test-Suite tests-mero-integration
                         distributed-process-test,
                         network-transport,
                         network-transport-inmemory,
+                        aeson,
                         cep,
                         confc,
                         rpclite,

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Hardware.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Hardware.hs
@@ -504,13 +504,14 @@ driveStatus dev = do
 
 -- | Update the status of a storage device.
 updateDriveStatus :: StorageDevice
-                  -> String
+                  -> String -- ^ Status.
+                  -> String -- ^ Reason.
                   -> PhaseM LoopState l ()
-updateDriveStatus dev status = modifyLocalGraph $ \rg -> do
-  phaseLog "rg" $ "Updating status for device " ++ show dev ++ " to " ++ status
+updateDriveStatus dev status reason = modifyLocalGraph $ \rg -> do
+  phaseLog "rg" $ "Updating status for device " ++ show dev ++ " to " ++ status ++ "("++reason++")"
   ds <- driveStatus dev
   phaseLog "rg" $ "Old status was " ++ show ds
-  let statusNode = StorageDeviceStatus status
+  let statusNode = StorageDeviceStatus status reason
       removeOldNode = case ds of
         Just f -> G.disconnect dev Is f
         Nothing -> id

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor.hs
@@ -237,7 +237,7 @@ ruleMeroNoteSet = do
                     updateDriveState m0sdev status
 
                     when (status == M0_NC_FAILED) $ do
-                      updateDriveManagerWithFailure sdev "FAILED" (Just "mero failure")
+                      updateDriveManagerWithFailure sdev "HALON-FAILED" (Just "MERO-Timeout")
                       nid <- liftProcess getSelfNode
                       diskids <- findStorageDeviceIdentifiers sdev
                       let iem = InterestingEventMessage . pack . unwords $ [
@@ -371,7 +371,7 @@ ruleResetAttempt = define "reset-attempt" $ do
         sd <- lookupStorageDeviceSDev sdev
         forM_ sd $ \m0sdev -> do
           updateDriveState m0sdev M0_NC_FAILED
-          updateDriveManagerWithFailure sdev "FAILED" (Just "unable to reset drive")
+          updateDriveManagerWithFailure sdev "HALON-FAILED" (Just "MERO-Timeout")
           pools <- getSDevPools m0sdev
           traverse_ startRepairOperation pools
 #endif

--- a/mero-halon/src/lib/HA/Resources/Castor.hs
+++ b/mero-halon/src/lib/HA/Resources/Castor.hs
@@ -102,8 +102,14 @@ instance Hashable DeviceIdentifier
 
 -- | Representation of storage device status. Currently this just mirrors
 --   the status we get from OpenHPI.
-newtype StorageDeviceStatus = StorageDeviceStatus String
-  deriving (Eq, Show, Generic, Typeable, Binary, Hashable)
+data StorageDeviceStatus = StorageDeviceStatus
+    { sdsStatus :: String
+    , sdsReason :: String
+    }
+  deriving (Eq, Show, Generic, Typeable)
+
+instance Binary StorageDeviceStatus
+instance Hashable StorageDeviceStatus
 
 -- | Resource indicating that core mero-server provisioning procedure
 -- is going happening on the node.

--- a/mero-halon/src/lib/HA/Services/SSPL.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL.hs
@@ -127,9 +127,18 @@ msgHandler msg = do
          sensorResponseMessageSensor_response_typeCpu_data
       sendMessage "SensorResponse.Raid"
          sensorResponseMessageSensor_response_typeRaid_data 
+      sendMessage "ActuatorResponse.ThreadController"
+         sensorResponseMessageSensor_response_typeRaid_data 
+
 
     Nothing -> case decode (msgBody msg) :: Maybe ActuatorResponse of
-      Just mr -> say $ "Ignoring acutator response: " ++ show mr
+      Just ar -> do 
+        let arms = actuatorResponseMessageActuator_response_type . actuatorResponseMessage $ ar
+            sendMessage s f = forM_ (f arms) $ \x -> do
+              saySSPL $ "received " ++ s
+              promulgate (nid, x)
+        sendMessage "ActuatorResponse.ThreadController"
+          actuatorResponseMessageActuator_response_typeThread_controller
       Nothing -> say $ "Unable to decode JSON message: " ++ (BL.unpack $ msgBody msg)
 
 startSensors :: Network.AMQP.Channel -- ^ AMQP Channel

--- a/mero-halon/tests/HA/RecoveryCoordinator/Mero/Tests.hs
+++ b/mero-halon/tests/HA/RecoveryCoordinator/Mero/Tests.hs
@@ -156,13 +156,13 @@ testDriveAddition transport = runDefaultTest transport $ do
   withTrackingStation emptyRules $ \(TestArgs _ mm _) -> do
     nodeUp ([nid], 1000000)
     -- Send host update message to the RC
-    promulgateEQ [nid] (nid, mockEvent "online" "" "/path") >>= flip withMonitor wait
+    promulgateEQ [nid] (nid, mockEvent "online" "NONE" "/path") >>= flip withMonitor wait
     "Drive" :: String <- expect
 
     graph <- G.getGraph mm
     let enc = Enclosure "enc1"
         drive = head (G.connectedTo enc Has graph :: [StorageDevice])
-        status = StorageDeviceStatus "online"
+        status = StorageDeviceStatus "online" "NONE"
     liftIO $ do
       assertBool "Enclosure exists in a graph"  $ G.memberResource enc graph
       assertBool "Drive exists in a graph"      $ G.memberResource drive graph
@@ -201,7 +201,7 @@ testDriveManagerUpdate transport = runDefaultTest transport $ do
     "InitialData" :: String <- expect
 
     say "Sending online message"
-    promulgateEQ [nid] (nid, respDM "online" "" "path") >>= flip withMonitor wait
+    promulgateEQ [nid] (nid, respDM "online" "NONE" "path") >>= flip withMonitor wait
     "DriveActive" :: String <- expect
 
     say "Checking drive status sanity"
@@ -211,7 +211,7 @@ testDriveManagerUpdate transport = runDefaultTest transport $ do
                       , sn == interestingSN
                   ]
     assert $ G.memberResource drive graph
-    assert $ G.memberResource (StorageDeviceStatus "online") graph
+    assert $ G.memberResource (StorageDeviceStatus "online" "NONE") graph
 
     say "Sending RunDriveManagerFailure"
     promulgateEQ [nid] RunDriveManagerFailure >>= flip withMonitor wait

--- a/mero-halon/tests/Helper/SSPL.hs
+++ b/mero-halon/tests/Helper/SSPL.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Helper.SSPL
   ( emptySensorMessage
+  , emptyActuatorMessage
   , emptyHPIMessage
   , emptyHostUpdate
   , mkSensorResponse
+  , mkActuatorResponse
   , mkResponseDriveManager
   , mkResponseHPI
   , mkHpiMessage
@@ -11,6 +13,7 @@ module Helper.SSPL
   ) where
 
 import Data.Text (Text)
+import qualified Data.Aeson as Aeson
 import qualified SSPL.Bindings as SSPL
 
 emptySensorMessage :: SSPL.SensorResponseMessageSensor_response_type
@@ -25,6 +28,12 @@ emptySensorMessage = SSPL.SensorResponseMessageSensor_response_type
   , SSPL.sensorResponseMessageSensor_response_typeRaid_data = Nothing
   }
 
+emptyActuatorMessage :: SSPL.ActuatorResponseMessageActuator_response_type
+emptyActuatorMessage = SSPL.ActuatorResponseMessageActuator_response_type
+  { SSPL.actuatorResponseMessageActuator_response_typeAck = Nothing
+  , SSPL.actuatorResponseMessageActuator_response_typeThread_controller = Nothing
+  , SSPL.actuatorResponseMessageActuator_response_typeService_controller = Nothing
+  }
 
 -- | Create stub sensor response
 mkSensorResponse :: SSPL.SensorResponseMessageSensor_response_type -> SSPL.SensorResponse
@@ -34,6 +43,16 @@ mkSensorResponse rsp = SSPL.SensorResponse
   , SSPL.sensorResponseExpires   = Nothing
   , SSPL.sensorResponseUsername  = "sspl"
   , SSPL.sensorResponseMessage   = SSPL.SensorResponseMessage Nothing rsp
+  }
+
+-- | Create stub actuator response.
+mkActuatorResponse :: SSPL.ActuatorResponseMessageActuator_response_type -> SSPL.ActuatorResponse
+mkActuatorResponse rsp = SSPL.ActuatorResponse
+  { SSPL.actuatorResponseSignature = "not-yet-implemented"
+  , SSPL.actuatorResponseTime      = "YYYY-MM-DD HH:mm"
+  , SSPL.actuatorResponseExpires   = Nothing
+  , SSPL.actuatorResponseUsername  = "sspl"
+  , SSPL.actuatorResponseMessage   = SSPL.ActuatorResponseMessage rsp Aeson.Null
   }
 
 -- | Create default HPI message.


### PR DESCRIPTION
*Created by: qnikst*

SSPL and RAS are stateless so they do not keep info about
devices that halon thinks are dead (e.g. drive that had more
failures then threshold allow). For such drive halon should
send notification to all sspl instance even in case of restarts.
For this when SSPL greets halon, halon checks if there are failed
drives and sends that information to SSPL via HDS messages.
Changes:
- Keep failed reason in StorageDeviceStatus
- Send ThreadController actuator messages to RC
- Introduce a rule that will check ThreadController messages
  and send drive states to SSPL
- Use HALON-FAILED as a status for devices that halon thinks
  are dead, the only possible reason currently is MERO-Timeout
- Test new test cases
