### PR TITLE
cep: introduce DropBuffer fork variant.

### DIFF
--- a/cep/cep/src/Network/CEP/Testing.hs
+++ b/cep/cep/src/Network/CEP/Testing.hs
@@ -24,7 +24,7 @@ runPhase :: forall g l. g       -- ^ Global state.
          -> PhaseM g l ()       -- ^ Phase to exec
          -> Process (g, [(Buffer, l)])      -- ^ Updated global and local state
 runPhase g l b p = do
-    (g', xs) <- runPhaseM "testing" MM.empty Nothing g l b p
+    (g', xs) <- runPhaseM "testing" MM.empty Nothing g l Nothing b p
     return (g', catMaybes $ fmap extract xs)
   where
     extract (b', po) = case po of

--- a/cep/cep/src/Network/CEP/Types.hs
+++ b/cep/cep/src/Network/CEP/Types.hs
@@ -439,8 +439,9 @@ data Scope g l a where
     Local  :: Scope g l l
 
 -- | When forking a new 'Phase' state machine, it possible to either copy
---   parent 'Buffer' or starting with an empty one.
-data ForkType = NoBuffer | CopyBuffer
+--   parent 'Buffer' or starting with an empty one, another option is to drop
+--   all messages that are older than one you work with.
+data ForkType = NoBuffer | CopyBuffer | CopyNewerBuffer
 
 -- | 'Phase' state machine.
 --


### PR DESCRIPTION
*Created by: qnikst*

DropBuffer fork variant introduces a rule that will drop all
messages that are older than current one from the buffer.
