### PR TITLE
Revert "Set principal RM ahead of trying to find it"

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Spiel.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Spiel.hs
@@ -550,8 +550,6 @@ getRPCAddress = do
 -- | RC wrapper for 'getSpielAddress'.
 getSpielAddressRC :: PhaseM LoopState l (Maybe M0.SpielAddress)
 getSpielAddressRC = do
-  rm <- pickPrincipalRM
-  phaseLog "debug:pickPrincipalRM" $ show rm
   phaseLog "rg-query" "Looking up confd and RM services for spiel address."
   getSpielAddress <$> getLocalGraph
 


### PR DESCRIPTION
*Created by: qnikst*

This reverts commit ee3cba2c51f9a4e22392ef381c9d7c6ae226c5cd.
