### PR TITLE
Implement blocking versions of notifyMero.

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -133,6 +133,7 @@ Library
                    binary,
                    network >= 2.4,
                    network-transport,
+                   replicated-log,
                    unordered-containers,
                    cep,
                    netwire,

--- a/mero-halon/src/lib/HA/Services/Mero/Types.hs
+++ b/mero-halon/src/lib/HA/Services/Mero/Types.hs
@@ -55,9 +55,15 @@ data MeroChannel = MeroChannel deriving (Eq, Show, Typeable, Generic)
 instance Binary MeroChannel
 instance Hashable MeroChannel
 
+-- | Acknowledgement sent upon successfully calling m0_ha_state_set
+newtype NotificationAck = NotificationAck ()
+  deriving (Binary, Eq, Hashable, Generic, Typeable)
+
 data NotificationMessage = NotificationMessage
        { notificationMessage :: Set
-       , notificationRecipients :: [String]
+       , notificationRecipients :: [String] -- Endpoints
+       , notificationAckTo :: [ProcessId] -- Processes to send ack that
+                                          -- notification is complete.
        }
      deriving (Typeable, Generic)
 instance Binary NotificationMessage

--- a/rpclite/Mero.hsc
+++ b/rpclite/Mero.hsc
@@ -109,13 +109,13 @@ replaceGlobalWorker tid = do
   wid <- readIORef globalM0Worker
   killThread wid
   writeIORef globalM0Worker tid
-  
-             
+
+
 
 data Task = forall a . Task (IO (Either SomeException a)) (MVar (Either SomeException a))
 
 -- | Send task to M0 worker, may throw 'M0InitException' if mero worker
--- failed to initialize mero.
+-- failed to initialize mero. This call blocks until the task is completed.
 sendM0Task :: IO a -> IO a
 sendM0Task f = do
     box <- newEmptyMVar


### PR DESCRIPTION
*Created by: nc6*

This took me an annoyingly long time to do, sorry...

Implementation isn't perfect, and I think a better way would be to remove `notifyMero` from `startRepairOperation` and use `notifyMeroAndThen` in the rule directly to control a phase transition. But I'm trying to work on submitting fixes which _don't_ refactor everything in sight...
