### PR TITLE
mero-halon: Catch exceptions in the status process.

### DIFF
--- a/mero-halon/src/lib/Mero/Notification/HAState.hsc
+++ b/mero-halon/src/lib/Mero/Notification/HAState.hsc
@@ -24,6 +24,7 @@ module Mero.Notification.HAState
   , FomV
   , entrypointReplyWakeup
   , entrypointNoReplyWakeup
+  , HAStateException(..)
   ) where
 
 import HA.Resources.Mero.Note


### PR DESCRIPTION
*Created by: facundominguez*

If any notification call failed, the status process would be terminated. Now it can survive some exceptions.
