### PR TITLE
Not all hosts are M0 servers.

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Conf.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Conf.hs
@@ -179,6 +179,7 @@ loadMeroServers fs = mapM_ goHost . offsetHosts where
                 >>> G.newResource ctrl
                 >>> G.newResource node
                 >>> G.connect Cluster Has host
+                >>> G.connect host Has HA_M0SERVER
                 >>> G.connect fs M0.IsParentOf node
                 >>> G.connect enc M0.IsParentOf ctrl
                 >>> G.connect ctrl M0.At host

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor.hs
@@ -610,7 +610,7 @@ goHost enc (CI.Host{..}) = let
     host = Host h_fqdn
     mem = fromIntegral h_memsize
     cpucount = fromIntegral h_cpucount
-    attrs = [HA_MEMSIZE_MB mem, HA_CPU_COUNT cpucount, HA_M0SERVER]
+    attrs = [HA_MEMSIZE_MB mem, HA_CPU_COUNT cpucount]
   in do
     registerHost host
     locateHostInEnclosure host enc

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Server.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Server.hs
@@ -122,6 +122,7 @@ ruleNewMeroServer = define "new-mero-server" $ do
           (_, _) -> return Nothing
 
   setPhase new_server $ \(HAEvent eid (NewMeroServer node@(Node nid)) _) -> fork CopyNewerBuffer $ do
+    phaseLog "info" $ "NewMeroServer received for node " ++ show nid
     put Local $ Just (node, eid)
     findNodeHost node >>= \case
       Just host -> alreadyBootstrapping nid <$> getLocalGraph >>= \case


### PR DESCRIPTION
*Created by: nc6*

- Only hosts with a 'Mero' section should get HA_M0SERVER.
- Log which nodes are being reported as servers.
