### PR TITLE
[HALON-172] Don't crash on out-of-range note state.

### DIFF
--- a/mero-halon/src/lib/HA/Resources/Mero/Note.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero/Note.hs
@@ -65,7 +65,7 @@ data ConfObjectState
       -- Rebalance process is complementary to repair: previously
       -- reconstructed data is being copied from spare space to the
       -- replacement storage.
-    deriving (Eq, Show, Enum, Typeable, Generic, Ord)
+    deriving (Eq, Show, Enum, Typeable, Generic, Ord, Bounded)
 
 instance Binary ConfObjectState
 instance Hashable ConfObjectState

--- a/mero-halon/src/lib/Mero/Notification.hs
+++ b/mero-halon/src/lib/Mero/Notification.hs
@@ -255,6 +255,7 @@ initialize_pre_m0_init lnode = initHAState ha_state_get
           liftGlobalM0 $ doneGet nvecr (-1)
 
     ha_state_set :: NVec -> IO Int
+    ha_state_set [] = return 0
     ha_state_set nvec = do
       CH.runProcess lnode $ do
         say $ "m0d: received state vector " ++ show nvec


### PR DESCRIPTION
*Created by: Fuuzetsu*

This uses an ugly hack: we define an enum conversion which is able to
throw an exception and a new type which is able to catch the exception
during `peek` and returns something that external callers can use to
determine if peek failed or not. The upside of this method is that we
can use existing peek functions (such as `peekArray`) and specify the
wanted behaviour with the `MaybeStorable` wrapper and the internal `peek`
uses existing `Storable` instance for underlying type. This means we
can ammend the main instance to throw an exception when something goes
wrong and `MaybeStorable` instance to catch the exception and signal
failure to the caller. Perhaps we should catch `SomeException`
instead.

But there are other ways to handle it, though all similiar. We could
skip `MaybeStorable` and use something like `MaybeNote` instead which
would do the same job but directly: `Note` would then not have a
`Storable` instance and we'd require explicit conversions. It has
similar ugliness as `MaybeNote` in that not all `MaybeNote`s would be
`poke`-able. Really we're victims of the `Storable` API: if we had a
pair of classes `Pokeable` and `Peekable`, this would be much nicer.

Another way is similar yet again but instead of using `Maybe`, in this
particular instance we could use `M0_NC_UNKNOWN` state but this seems
like a huge abuse and we would not be able to tell if some mero
component genuinely sent the status.

Note that this does not solve the harder problem of what to do if
multimap process dies (as it did in this scenario), taking RS with it.
