### PR TITLE
HALON-180: Add 'version' command to halond.

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -290,12 +290,16 @@ Executable halond
                       StandaloneDeriving
   Other-Extensions:   CPP
   if flag(mero)
-    CPP-Options:    -DUSE_MERO
+    c-sources:        src/halond/Version.c
+    cc-options:       -Wno-attributes -Werror -g -DM0_INTERNAL= -DM0_EXTERN=extern
+    CPP-Options:      -DUSE_MERO
   if flag(rpc)
       CPP-Options:    -DUSE_RPC
   Build-Depends:      halon,
                       binary,
                       directory,
+                      gitrev,
+                      inline-c,
                       mero-halon,
                       base >= 4.5,
                       distributed-commands,

--- a/mero-halon/src/halond/Flags.hs
+++ b/mero-halon/src/halond/Flags.hs
@@ -2,7 +2,7 @@
 -- Copyright : (C) 2013 Xyratex Technology Limited.
 -- License   : All rights reserved.
 
-module Flags (Config(..), parseArgs) where
+module Flags (Config(..), Mode(..), helpString, parseArgs) where
 
 import System.Console.GetOpt
 import Control.Exception (throw)
@@ -15,6 +15,9 @@ data Config = Config
     , localEndpoint :: String
     }
 
+header :: String
+header = "Usage: halond [OPTION...]"
+
 defaultConfig :: Config
 defaultConfig = Config
     { mode = Run
@@ -26,7 +29,7 @@ options :: [OptDescr (Config -> Config)]
 options =
     [ Option [] ["help"] (NoArg $ \c -> c{ mode = Help })
                  "This help message."
-    , Option [] ["version"] (NoArg $ \c -> c{ mode = Version })
+    , Option ['v'] ["version"] (NoArg $ \c -> c{ mode = Version })
                  "Display version information."
     , Option ['c'] ["config"] (ReqArg (\fp c -> c{ configFile = Just fp }) "FILE")
                  "Configuration file."
@@ -36,7 +39,9 @@ options =
 
 parseArgs :: [String] -> Config
 parseArgs argv =
-    case getOpt Permute options argv of
-      (setOpts,[],[]) -> foldr (.) id setOpts defaultConfig
-      (_,_,errs) -> throw $ userError $ concat errs ++ usageInfo header options
-  where header = "Usage: halond [OPTION...]"
+  case getOpt Permute options argv of
+    (setOpts,[],[]) -> foldr (.) id setOpts defaultConfig
+    (_,_,errs) -> throw $ userError $ concat errs ++ usageInfo header options
+
+helpString :: String
+helpString = usageInfo header options

--- a/mero-halon/src/halond/Version.hs
+++ b/mero-halon/src/halond/Version.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP #-}
+
+-- |
+-- Copyright : (C) 2016 Seagate Technology Limited.
+-- License   : All rights reserved.
+-- Module to print Halon version information.
+
+module Version where
+
+import Data.List (intercalate)
+import Development.GitRev
+
+import Text.Printf (printf)
+
+#ifdef USE_MERO
+import Foreign.C.String (peekCAString)
+
+import qualified Language.C.Inline as C
+
+C.include "mero/version.h"
+
+-- | Show version information
+versionString :: IO String
+versionString = do
+  mero_build_desc <-
+    peekCAString =<< [C.exp| const char* { m0_build_info_get()->bi_git_describe } |]
+  mero_runtime_desc <-
+    peekCAString =<< [C.exp| const char* { M0_VERSION_GIT_DESCRIBE } |]
+  mero_build_version <-
+    peekCAString =<< [C.exp| const char* { m0_build_info_get()->bi_git_rev_id } |]
+  mero_runtime_version <-
+    peekCAString =<< [C.exp| const char* { M0_VERSION_GIT_REV_ID } |]
+  mero_build_opts <-
+    peekCAString =<< [C.exp| const char* { m0_build_info_get()->bi_configure_opts } |]
+  mero_runtime_opts <-
+    peekCAString =<< [C.exp| const char* { M0_VERSION_BUILD_CONFIGURE_OPTS } |]
+  return $ printf (intercalate "\n" [
+        "Halon %s (Git revision: %s)"
+      , "Built against:"
+      , "Mero: %s (Git revision: %s) (Configure flags: %s)"
+      , "Running against:"
+      , "Mero: %s (Git revision: %s) (Configure flags: %s)"
+      ])
+    ($(gitDescribe) :: String) ($(gitHash) :: String)
+    mero_build_desc mero_build_version mero_build_opts
+    mero_runtime_desc mero_runtime_version mero_runtime_opts
+
+#else
+versionString :: IO String
+versionString =
+  return $ printf (intercalate "\n" [
+        "Halon %s (Git revision: %s)"
+      , "Built without Mero integration."
+      ])
+    ($(gitDescribe) :: String) ($(gitHash) :: String)
+#endif

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,6 +28,10 @@ packages:
   extra-dep: true
 - location: vendor/tasty-files
   extra-dep: true
+- location:
+    git: https://github.com/nc6/gitrev.git
+    commit: 52f4c1c96c776ca74bf9f9b01808b0c1d5e0ac94
+  extra-dep: true
 
 extra-deps:
 - aeson-schema-0.4.0.0


### PR DESCRIPTION
*Created by: nc6*

- `halond -v` will print version and git commits of halon and mero.
- Get `--help` to do what it should.
