### PR TITLE
HALON-195: Fix memory consumption happened because of SSPL serviece r…

### DIFF
--- a/mero-halon/src/lib/HA/Services/SSPL/CEP.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/CEP.hs
@@ -184,6 +184,7 @@ ssplRulesF sspl = sequence_
   , ruleHlNodeCmd sspl
   , ruleThreadController
   , ruleSSPLTimeout sspl
+  , ruleSSPLConnectFailure
   ]
 
 ruleDeclareChannels :: Definitions LoopState ()
@@ -501,4 +502,10 @@ ruleSSPLTimeout sspl = defineSimple "sspl-service-timeout" $
           mservice <- lookupRunningService (Node node) sspl
           forM_ mservice $ \(ServiceProcess pid) ->
             liftProcess $ usend pid ResetSSPLService
+          messageProcessed uuid
+
+ruleSSPLConnectFailure :: Definitions LoopState ()
+ruleSSPLConnectFailure = defineSimple "sspl-service-connect-failure" $
+      \(HAEvent uuid (SSPLConnectFailure nid) _) -> do
+          phaseLog "error" $ "SSPL service can't connect to rabbitmq on node: " ++ show nid
           messageProcessed uuid

--- a/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
@@ -219,6 +219,10 @@ data ResetSSPLService = ResetSSPLService
 
 instance Binary ResetSSPLService
 
+-- | Event happens when SSPL can't connect to Rabbit-MQ broker
+newtype SSPLConnectFailure = SSPLConnectFailure NodeId
+   deriving (Eq, Show, Binary, Typeable)
+
 --------------------------------------------------------------------------------
 -- Channels                                                                   --
 --------------------------------------------------------------------------------


### PR DESCRIPTION
*Created by: qnikst*

…estarts.

If SSPL service can't connect to rabbitmq (possibly due to missing rabbitmq on
the nodes) it tries to reconnect in a loop. Now service check if the problem
happened on connect to RabbitMQ and stops service if that happened.
