### PR TITLE
HALON-44 Don't retry requests to replicas after fixed timeouts.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,6 +45,6 @@ test:
     # Only test mero-halon and deps, without USE_MERO.
     # Testing with USE_MERO is not possible since m0_init fails when some cpus
     # on the host are forbidden via cpusets as circleci does.
-    - stack $STACK_FLAGS --docker-env DC_PROVIDER=docker --docker-env DOCKER_HOST=http://172.17.42.1:5555 --docker-env DC_HOST_IP=172.17.42.1 --docker-env HALON_TRACING='consensus-paxos replicated-log EQ EQ.producer MM RS RG' build --flag mero-halon:distributed-tests --haddock --no-haddock-deps --test:
+    - stack $STACK_FLAGS --docker-env DC_PROVIDER=docker --docker-env DOCKER_HOST=http://172.17.42.1:5555 --docker-env DC_HOST_IP=172.17.42.1 --docker-env HALON_TRACING='consensus-paxos replicated-log EQ EQ.producer MM RS RG call' build --flag mero-halon:distributed-tests --haddock --no-haddock-deps --test:
         timeout: 3600
     - scripts/copy_artifacts.sh "${CIRCLE_ARTIFACTS}"

--- a/halon/src/lib/HA/Startup.hs
+++ b/halon/src/lib/HA/Startup.hs
@@ -17,7 +17,7 @@ import qualified HA.EQTracker as EQT
 import HA.Multimap ( MetaInfo, defaultMetaInfo, StoreChan )
 import HA.Multimap.Implementation ( Multimap, fromList )
 import HA.Multimap.Process ( startMultimap )
-import HA.Replicator ( RGroup(..), RStateView(..) )
+import HA.Replicator ( RGroup(..), RStateView(..), retryRGroup )
 import HA.Replicator.Log ( RLogGroup )
 import qualified HA.Storage as Storage
 
@@ -33,7 +33,6 @@ import qualified Control.Distributed.Process.Internal.StrictMVar as StrictMVar
     ( modifyMVar_ )
 import Control.Distributed.Process.Internal.Types
 import Control.Distributed.Process.Serializable ( SerializableDict(..) )
-import Control.Distributed.Process.Timeout ( retry )
 import Control.Distributed.Static ( closureApply )
 import Control.Exception (SomeException)
 
@@ -246,7 +245,7 @@ remotableDecl [ [d|
     nid <- getSelfNode
     cRGroup <- spawnReplica $(mkStatic 'rsDict) nid
     rGroup <- unClosure cRGroup >>= id
-    nids <- retry 1000000 $ getRGroupMembers rGroup
+    nids <- retryRGroup rGroup 1000000 $ getRGroupMembers rGroup
     let rcClosure' = rcClosure `closureApply` (closure
                                                 $(mkStatic 'decodeNids)
                                                 (encode nids)

--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -364,6 +364,7 @@ Test-Suite distributed-tests
       HA.Test.Distributed.RCInsists2
       HA.Test.Distributed.Snapshot3
       HA.Test.Distributed.StartService
+      HA.Test.Distributed.StressRC
       HA.Test.Distributed.TSDisconnects
       HA.Test.Distributed.TSDisconnects2
       HA.Test.Distributed.TSRecovers

--- a/mero-halon/src/halond/Main.hs
+++ b/mero-halon/src/halond/Main.hs
@@ -72,7 +72,7 @@ main = do
         -- spawning remote processes.
         whenTestIsDistributed $
           setEnvIfUnset "HALON_TRACING"
-            "consensus-paxos replicated-log EQ EQ.producer MM RS RG"
+            "consensus-paxos replicated-log EQ EQ.producer MM RS RG call"
 #ifdef USE_RPC
         rpcTransport <- RPC.createTransport "s1"
                                             (RPC.rpcAddress $ localEndpoint config)

--- a/mero-halon/tests/HA/Test/Distributed/StressRC.hs
+++ b/mero-halon/tests/HA/Test/Distributed/StressRC.hs
@@ -1,0 +1,119 @@
+-- |
+-- Copyright : (C) 2014 Xyratex Technology Limited.
+-- License   : All rights reserved.
+--
+-- This test exhibits starting a simple cluster over two nodes and stressing the
+-- RC with many events.
+--
+-- We start two instances of `halond` on two nodes. We then start the TS in one
+-- of them and a satellite in the other. Then we start the ping service and send
+-- many pings.
+--
+module HA.Test.Distributed.StressRC where
+
+import qualified Control.Exception as IO (bracket)
+import Control.Distributed.Commands.Management (withHostNames)
+import Control.Distributed.Commands.Process
+  ( copyFiles
+  , systemThere
+  , spawnNode_
+  , copyLog
+  , expectLog
+  , __remoteTable
+  )
+import Control.Distributed.Commands.Providers
+  ( getHostAddress
+  , getProvider
+  )
+
+import Control.Distributed.Process
+import Control.Distributed.Process.Node
+  ( initRemoteTable
+  , runProcess
+  )
+
+import Control.Monad(forM_)
+import Data.List (isInfixOf)
+import HA.Service hiding (__remoteTable)
+import qualified HA.Services.Ping as Ping
+
+import Network.Transport (closeTransport)
+import Network.Transport.TCP (createTransport, defaultTCPParameters)
+
+import Test.Framework (withLocalNode, getBuildPath)
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (testCase)
+import System.FilePath ((</>))
+import System.Timeout
+
+
+test :: TestTree
+test = testCase "StressRC [disabled until fixed]" $ const (return ()) $
+  (>>= maybe (error "test timed out") return) $ timeout (120 * 1000000) $
+  getHostAddress >>= \ip ->
+  IO.bracket (do Right nt <- createTransport ip "4000" defaultTCPParameters
+                 return nt
+             ) closeTransport $ \nt ->
+  withLocalNode nt (__remoteTable initRemoteTable) $ \n0 -> do
+    cp <- getProvider
+    buildPath <- getBuildPath
+
+    withHostNames cp 2 $  \ms@[m0, m1] ->
+     runProcess n0 $ do
+      let m0loc = m0 ++ ":9000"
+          m1loc = m1 ++ ":9000"
+          halonctlloc = (++ ":9001")
+
+      say "Copying binaries ..."
+      -- test copying a folder
+      copyFiles "localhost" ms [ (buildPath </> "halonctl/halonctl", "halonctl")
+                               , (buildPath </> "halond/halond", "halond") ]
+
+      say "Running a remote test command ..."
+      systemThere ms ("echo can run a remote command")
+
+      getSelfPid >>= copyLog (const True)
+
+      say "Spawning halond ..."
+      nid0 <- spawnNode_ m0 ("./halond -l " ++ m0loc ++ " 2>&1")
+      nid1 <- spawnNode_ m1 ("./halond -l " ++ m1loc ++ " 2>&1")
+
+      say "Spawning tracking station ..."
+      systemThere [m0] ("./halonctl"
+                     ++ " -l " ++ halonctlloc m0
+                     ++ " -a " ++ m0loc
+                     ++ " bootstrap station" ++ " 2>&1"
+                     )
+
+      expectLog [nid0] (isInfixOf "New replica started in legislature://0")
+
+      say "Starting satellite nodes ..."
+      -- this runs on one node but it should control both nodes (?)
+      systemThere [m0] ("./halonctl"
+                     ++ " -l " ++ halonctlloc m0
+                     ++ " -a " ++ m1loc
+                     ++ " bootstrap satellite"
+                     ++ " -t " ++ m0loc ++ " 2>&1")
+      expectLog [nid0] (isInfixOf $ "New node contacted: nid://" ++ m1loc)
+      expectLog [nid0, nid1] (isInfixOf "Node succesfully joined the cluster.")
+
+      say "Starting ping service ..."
+      systemThere [m0] $ "./halonctl"
+          ++ " -l " ++ halonctlloc m0
+          ++ " -a " ++ m1loc
+          ++ " service ping start -t " ++ m0loc ++ " 2>&1"
+      expectLog [nid0] (isInfixOf "started ping service")
+
+      say "Where is ..."
+      whereisRemoteAsync nid1 $ serviceLabel $ serviceName Ping.ping
+      WhereIsReply _ (Just pingPid) <- expect
+      say "Sending a test ping ..."
+      send pingPid "0"
+      expectLog [nid0] $ isInfixOf "received DummyEvent 0"
+
+      let numPings = 2000 :: Int
+      say $ "Sending " ++ show numPings ++ " pings ..."
+      forM_ [0..numPings] $ send pingPid . show
+
+      forM_ [0..numPings] $ \i ->
+        expectLog [nid0] $ isInfixOf $ "received DummyEvent " ++ show i

--- a/mero-halon/tests/HA/Test/Distributed/TSDisconnects2.hs
+++ b/mero-halon/tests/HA/Test/Distributed/TSDisconnects2.hs
@@ -106,11 +106,16 @@ test = testCase "TSDisconnects2" $
       systemThere [m0] $ "./halonctl"
                       ++ " -l " ++ halonctlloc m0
                       ++ " -a " ++ m3loc
-                      ++ " service ping start -t " ++ m0loc ++ " 2>&1"
+                      ++ " service ping start"
+                      ++ " -t " ++ m0loc
+                      ++ " -t " ++ m1loc
+                      ++ " -t " ++ m2loc
+                      ++ " 2>&1"
       expectLog tsNodes (isInfixOf "started ping service")
 
       whereisRemoteAsync nid3 $ serviceLabel $ serviceName Ping.ping
       WhereIsReply _ (Just pingPid) <- expect
+      say "Testing ping service ..."
       send pingPid "0"
       expectLog tsNodes $ isInfixOf "received DummyEvent 0"
 

--- a/mero-halon/tests/distributed-tests.hs
+++ b/mero-halon/tests/distributed-tests.hs
@@ -14,6 +14,7 @@ import qualified HA.Test.Distributed.RCInsists
 import qualified HA.Test.Distributed.RCInsists2
 import qualified HA.Test.Distributed.Snapshot3
 import qualified HA.Test.Distributed.StartService
+import qualified HA.Test.Distributed.StressRC
 import qualified HA.Test.Distributed.TSDisconnects
 import qualified HA.Test.Distributed.TSDisconnects2
 import qualified HA.Test.Distributed.TSRecovers
@@ -37,6 +38,7 @@ tests = testGroup "mero-halon" $ (:[]) $
       , HA.Test.Distributed.RCInsists.test
       , HA.Test.Distributed.RCInsists2.test
       , HA.Test.Distributed.Snapshot3.test
+      , HA.Test.Distributed.StressRC.test
       , HA.Test.Distributed.StartService.test
       , HA.Test.Distributed.TSDisconnects.test
       , HA.Test.Distributed.TSDisconnects2.test

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -58,4 +58,4 @@ CEP_DIR = $(ROOT_DIR)/cep/
 
 CEP_PACKAGES := cep
 
-export HALON_TRACING = consensus-paxos replicated-log EQ EQ.producer MM RS RG
+export HALON_TRACING = consensus-paxos replicated-log EQ EQ.producer MM RS RG call

--- a/replicated-log/replicated-log.cabal
+++ b/replicated-log/replicated-log.cabal
@@ -29,6 +29,7 @@ Library
                     Control.Distributed.Log.Policy
                     Control.Distributed.Log.Snapshot
                     Control.Distributed.Process.Batcher
+                    Control.Distributed.Process.Monitor
                     Control.Distributed.Process.ProcessPool
                     Control.Distributed.Process.Timeout
                     Control.Distributed.State
@@ -96,6 +97,7 @@ Test-Suite tests
                     distributed-process-scheduler,
                     distributed-process-test,
                     distributed-static >= 0.2.0,
+                    exceptions >= 0.8.0.2,
                     filepath >= 1.3,
                     mtl >= 2.0.0,
                     network >= 2.4.2.3,
@@ -138,6 +140,7 @@ Test-Suite scheduler-tests
                     distributed-process-scheduler,
                     distributed-process-test,
                     distributed-static >= 0.2.0,
+                    exceptions >= 0.8.0.2,
                     filepath >= 1.3,
                     mtl >= 2.0.0,
                     network >= 2.4.2.3,
@@ -148,6 +151,7 @@ Test-Suite scheduler-tests
                     rank1dynamic >= 0.1,
                     replicated-log,
                     tasty,
+                    tasty-files,
                     unix
   Default-Extensions: DeriveDataTypeable
                       DeriveGeneric

--- a/replicated-log/src/Control/Distributed/Log.hs
+++ b/replicated-log/src/Control/Distributed/Log.hs
@@ -24,6 +24,7 @@ module Control.Distributed.Log
     , status
     , reconfigure
     , recover
+    , monitorLog
     , addReplica
     , killReplica
     , removeReplica

--- a/replicated-log/src/Control/Distributed/Process/Monitor.hs
+++ b/replicated-log/src/Control/Distributed/Process/Monitor.hs
@@ -1,0 +1,63 @@
+-- |
+-- Copyright : (C) 2013 Xyratex Technology Limited.
+-- License   : All rights reserved.
+--
+-- Functions to interrupt actions when monitor notifications arrive.
+--
+module Control.Distributed.Process.Monitor
+    ( retryMonitoring
+    , withMonitoring
+    ) where
+
+import Control.Distributed.Process
+    ( exit
+    , link
+    , matchIf
+    , newChan
+    , receiveChan
+    , receiveTimeout
+    , receiveWait
+    , sendChan
+    , spawnLocal
+    , unlink
+    , MonitorRef
+    , Process
+    , ProcessLinkException(..)
+    , ProcessMonitorNotification(..)
+    )
+
+import Control.Monad (join)
+import Control.Monad.Catch
+
+
+-- | Runs the given action, but returns 'Nothing' if monitoring
+-- produces a notification.
+--
+-- See 'monitorLog'.
+--
+withMonitoring :: Process MonitorRef -> Process b -> Process (Maybe b)
+withMonitoring mon action = do
+    (sp, rp) <- newChan
+    pid <- spawnLocal $ do
+      ref <- mon
+      sendChan sp ()
+      receiveWait
+        [ matchIf (\(ProcessMonitorNotification ref' _ _) -> ref == ref')
+                  $ const (return ())
+        ]
+    bracket_ (link pid) (unlink pid >> exit pid "withMonitoring finished") $ do
+      receiveChan rp
+      fmap Just action
+     `catch` \e@(ProcessLinkException pid' _ ) ->
+        if pid == pid'
+          then return Nothing
+          else throwM e
+
+-- | Runs the given action using 'withMonitoingr'. If it produces 'Nothing', it
+-- waits the given delay of microseconds and retries repeteadly until the action
+-- succeeds or fails with an exception.
+retryMonitoring :: Process MonitorRef -> Int -> Process (Maybe b) -> Process b
+retryMonitoring mon delay action =
+    withMonitoring mon action >>=
+      maybe (receiveTimeout delay [] >> retryMonitoring mon delay action) return
+      . join

--- a/replicated-log/tests/scheduler-tests.hs
+++ b/replicated-log/tests/scheduler-tests.hs
@@ -5,14 +5,16 @@
 import Test (tests)
 
 import Control.Distributed.Process.Scheduler
-import Test.Driver
 
 import Control.Concurrent
 import Control.Exception
 import Control.Monad
-import Test.Tasty (testGroup)
+import Test.Tasty
 import Test.Tasty.Environment
+import Test.Tasty.Ingredients.FileReporter
+import Test.Tasty.Ingredients.Basic
 import System.Posix.Env (setEnv)
+import System.Environment (withArgs)
 
 
 main :: IO ()
@@ -32,3 +34,15 @@ main = do
         runnerArgs
     else
       error "The scheduler is not enabled."
+
+defaultMainWithArgs :: ([String] -> IO TestTree)
+                    -- ^ Action taking a list of 'String' from stdarg and returning
+                    -- 'Tests's to run.
+                    -> [String]
+                    -- ^ Arguments to pass to tast framework.
+                    -> [String]
+                    -- ^ Arguments to pass to test creation action.
+                    -> IO ()
+defaultMainWithArgs testsF runnerArgs testArgs = do
+    testsF testArgs >>= withArgs runnerArgs .
+      defaultMainWithIngredients [fileTestReporter [consoleTestReporter]]


### PR DESCRIPTION
*Created by: facundominguez*

The inconveniencies of retrying with timeouts are discussed in
https://jira.xyratex.com/browse/HALON-44

The group of replicas can be monitored now for disconnections or epoch
changes. In addition, requests may get a notification if the replicas
drop the requests for whatever reason.

EQs, RSs and MM retry requests only if they are notified of problems
with the requests or the replicas.

The clients of EQs, in turn, now have to monitor EQs when sending events.
Retrying is only necessary if the EQs are disconnected or if
notifications of errors in EQs arrive.

The logic in EQs had to be modified so they always send a reply to
clients whether requests are served or not.

Fixes HALON-44
