### PR TITLE
Use build rather than install bins in RPM.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,9 +204,9 @@ check-freeze:
 # and a pseudo-source tar in ./rpmbuild/SRPMS
 rpm:
 	mkdir -p rpmbuild/SOURCES/role_maps
-	cp .stack-work/install/x86_64-linux/lts-3.11/7.10.2/bin/halond rpmbuild/SOURCES/
-	cp .stack-work/install/x86_64-linux/lts-3.11/7.10.2/bin/halonctl rpmbuild/SOURCES/
-	cp .stack-work/install/x86_64-linux/lts-3.11/7.10.2/bin/genders2yaml rpmbuild/SOURCES/
+	cp mero-halon/.stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/halond/halond rpmbuild/SOURCES/
+	cp mero-halon/.stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/halonctl/halonctl rpmbuild/SOURCES/
+	cp mero-halon/.stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/genders2yaml/genders2yaml rpmbuild/SOURCES/
 	cp systemd/halond.service rpmbuild/SOURCES/
 	cp systemd/halon-satellite.service rpmbuild/SOURCES/
 	cp mero-halon/scripts/localcluster rpmbuild/SOURCES/halon-simplelocalcluster


### PR DESCRIPTION
*Created by: nc6*

This should give access to debug symbols.
