### PR TITLE
.gitignore: add tags and runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,15 @@ rpclite/rpclite/test?
 rpclite/rpclite/test
 rpclite/rpclite/test-epoch
 mero-halon/src/halond/Version.c
+m0trace.*
+core
+core.*
+/tags
+/TAGS
+/cscope.*
+/ncscope.*
+GPATH
+GRTAGS
+GSYMS
+GTAGS
+*.swp


### PR DESCRIPTION
*Created by: mmedved*

- m0trace.PID;
- core files;
- ctags, cscope, emacs tag files, gnu global files;
- vim's .swp files.
