### PR TITLE
Change safety of the methods that can block.

### DIFF
--- a/mero-halon/src/lib/Mero/Notification/HAState.hsc
+++ b/mero-halon/src/lib/Mero/Notification/HAState.hsc
@@ -212,7 +212,7 @@ foreign import ccall unsafe ha_state_fini :: IO ()
 doneGet :: NVecRef -> Int -> IO ()
 doneGet p = ha_state_get_done p . fromIntegral
 
-foreign import ccall unsafe ha_state_get_done :: NVecRef -> CInt -> IO ()
+foreign import ccall ha_state_get_done :: NVecRef -> CInt -> IO ()
 
 -- | Notifies mero at the remote address that the state of some objects has
 -- changed.
@@ -246,7 +246,7 @@ check_rc msg i = throwIO $ HAStateException msg $ fromIntegral i
 data EntryPointRepV
 data FomV
 
-foreign import ccall unsafe ha_entrypoint_reply_wakeup
+foreign import ccall ha_entrypoint_reply_wakeup
   :: Ptr FomV -> Ptr EntryPointRepV -> CInt
   -> CInt -> Ptr Fid
   -> CInt -> Ptr CString


### PR DESCRIPTION
*Created by: qnikst*

All C calls that are long (>10us) and especially ones that can
block should not be imported as unsafe. Otherwise HEC that
run those methods will be blocked.
Callback in ha state are using 'm0_fop_wakeup' that is blocking,
so they should not be marked as unsafe.
