### PR TITLE
HALON-271: Support new Mero performance parameters in initial data.

### DIFF
--- a/mero-halon/src/genders2yaml/Main.hs
+++ b/mero-halon/src/genders2yaml/Main.hs
@@ -89,6 +89,20 @@ makeInitialData db devs = CI.InitialWithRoles {
     , CI.m0_parity_units = 1
     , CI.m0_md_redundancy = 2
     , CI.m0_failure_set_gen = CI.Dynamic
+    , CI.m0_be_ios_seg_size = 549755813888
+    , CI.m0_be_log_size = 17179869184
+    , CI.m0_be_seg_size = 549755813888
+    , CI.m0_be_tx_payload_size_max = 2097152
+    , CI.m0_be_tx_reg_nr_max = 262144
+    , CI.m0_be_tx_reg_size_max = 33554432
+    , CI.m0_be_txgr_freeze_timeout_max = 300
+    , CI.m0_be_txgr_freeze_timeout_min = 300
+    , CI.m0_be_txgr_payload_size_max = 134217728
+    , CI.m0_be_txgr_reg_nr_max = 2097152
+    , CI.m0_be_txgr_reg_size_max = 536870912
+    , CI.m0_be_txgr_tx_nr_max = 82
+    , CI.m0_block_size = 4096
+    , CI.m0_min_rpc_recvq_len = 2048
     }
   , CI._rolesinit_id_racks = [
       CI.Rack {

--- a/mero-halon/src/lib/HA/Resources/Castor/Initial.hs
+++ b/mero-halon/src/lib/HA/Resources/Castor/Initial.hs
@@ -122,6 +122,20 @@ data M0Globals = M0Globals {
   , m0_parity_units :: Word32  -- ^ As in genders
   , m0_md_redundancy :: Word32 -- ^ Metadata redundancy count
   , m0_failure_set_gen :: FailureSetScheme
+  , m0_be_ios_seg_size :: Word64
+  , m0_be_log_size :: Word64
+  , m0_be_seg_size :: Word64
+  , m0_be_tx_payload_size_max :: Word64
+  , m0_be_tx_reg_nr_max :: Word32
+  , m0_be_tx_reg_size_max :: Word32
+  , m0_be_txgr_freeze_timeout_max :: Word64
+  , m0_be_txgr_freeze_timeout_min :: Word64
+  , m0_be_txgr_payload_size_max :: Word64
+  , m0_be_txgr_reg_nr_max :: Word64
+  , m0_be_txgr_reg_size_max :: Word64
+  , m0_be_txgr_tx_nr_max :: Word32
+  , m0_block_size :: Word32
+  , m0_min_rpc_recvq_len :: Word32
 } deriving (Eq, Data, Generic, Show, Typeable)
 
 instance Binary M0Globals

--- a/mero-halon/tests/Helper/InitialData.hs
+++ b/mero-halon/tests/Helper/InitialData.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 module Helper.InitialData
   ( defaultGlobals
   , defaultInitialData
@@ -13,12 +14,27 @@ import Data.Maybe (fromMaybe)
 
 import Helper.Environment
 
+-- Defaults taken from http://es-gerrit.xyus.xyratex.com:8080/#/c/10913/1/modules/stx_halon/manifests/facts.pp
 defaultGlobals :: CI.M0Globals
 defaultGlobals = CI.M0Globals {
     CI.m0_data_units = 8
   , CI.m0_parity_units = 2
-  , CI.m0_md_redundancy = 2
+  , CI.m0_md_redundancy = 1
   , CI.m0_failure_set_gen = CI.Preloaded 0 1 0
+  , CI.m0_be_ios_seg_size = 549755813888
+  , CI.m0_be_log_size = 17179869184
+  , CI.m0_be_seg_size = 549755813888
+  , CI.m0_be_tx_payload_size_max = 2097152
+  , CI.m0_be_tx_reg_nr_max = 262144
+  , CI.m0_be_tx_reg_size_max = 33554432
+  , CI.m0_be_txgr_freeze_timeout_max = 300
+  , CI.m0_be_txgr_freeze_timeout_min = 300
+  , CI.m0_be_txgr_payload_size_max = 134217728
+  , CI.m0_be_txgr_reg_nr_max = 2097152
+  , CI.m0_be_txgr_reg_size_max = 536870912
+  , CI.m0_be_txgr_tx_nr_max = 82
+  , CI.m0_block_size = 4096
+  , CI.m0_min_rpc_recvq_len = 2048
 }
 
 -- | Create initial data for use in tests.
@@ -28,12 +44,16 @@ initialData :: String -- ^ Hostname prefix (or hostname if only one host)
             -> Int -- ^ Number of drives per server
             -> CI.M0Globals -- ^ Mero globals
             -> CI.InitialData
-initialData _ _ s ds (CI.M0Globals d p _ _) | (s*ds) < fromIntegral (d +2*p) =
-  error $ "initialData: the given number of devices ("
-        ++ show (s*ds)
-        ++ ") is smaller than 2 * parity_units + data_units (= "
-        ++ show (d + 2*p)
-        ++ ")."
+initialData _ _ s ds (CI.M0Globals {..}) | (s*ds) < fromIntegral (d +2*p) =
+    error $ "initialData: the given number of devices ("
+          ++ show (s*ds)
+          ++ ") is smaller than 2 * parity_units + data_units (= "
+          ++ show (d + 2*p)
+          ++ ")."
+  where
+    d = m0_data_units
+    p = m0_parity_units
+
 initialData host_pfx ifaddr_pfx n_srv n_drv globs = CI.InitialData {
     CI.id_m0_globals = globs
   , CI.id_racks = [


### PR DESCRIPTION
*Created by: nc6*

Corresponding ticket in Mero is MERO-1731, and provisioner work
is in http://es-gerrit.xyus.xyratex.com:8080/#/c/10913

This commit simply allows these globals to be defined. Additional
work is required in order to provide these parameters to Mero.
