### PR TITLE
[HALON-279] Don't try to start already started processes

### DIFF
--- a/cep/cep/src/Network/CEP/Types.hs
+++ b/cep/cep/src/Network/CEP/Types.hs
@@ -556,8 +556,7 @@ publish e = singleton $ Publish e
 
 -- | Simple log. First parameter is the context and the last one is the log.
 phaseLog :: String -> String -> PhaseM g l ()
-phaseLog ctx line = -- liftProcess . say $ ctx ++ " => " ++ line
-  singleton $ PhaseLog ctx line
+phaseLog ctx line = singleton $ PhaseLog ctx line
 
 -- | Changes state machine context. Given the list of 'PhaseHandle', switch to
 --   the first 'Phase' that's successfully executed.

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Cluster.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Cluster.hs
@@ -195,7 +195,7 @@ ruleServiceNotificationHandler = define "service-notification-handler" $ do
                        switch [process_notified, timeout 15 timed_out]
 
                else do phaseLog "info" $ "Still waiting to hear from "
-                                      ++ show (allSrvs \\ onlineSrvs)
+                                      ++ show (map M0.fid $ allSrvs \\ onlineSrvs)
                        continue finish
              (M0.SSOffline, Just p) -> case M0.getState p rg of
                M0.PSInhibited{} -> do
@@ -722,6 +722,8 @@ ruleNewMeroServer = define "new-mero-server" $ do
       case m0svc >>= meroChannel rg of
         Just chan -> do
           procs <- startNodeProcesses host chan (M0.PLBootLevel (M0.BootLevel 0)) True
+          when (null procs) $ do
+            phaseLog "warn" "Empty list of processes being started"
           switch [boot_level_1, timeout 180 finish]
         Nothing -> do
           phaseLog "warning" "service was not found can't start processes"
@@ -734,6 +736,8 @@ ruleNewMeroServer = define "new-mero-server" $ do
       case m0svc >>= meroChannel g of
         Just chan -> do
           procs <- startNodeProcesses host chan (M0.PLBootLevel (M0.BootLevel 1)) True
+          when (null procs) $ do
+            phaseLog "warn" "Empty list of processes being started"
           switch [start_clients, timeout 180 finish]
         Nothing -> do
           phaseLog "error" $ "Can't find service for node " ++ show node


### PR DESCRIPTION
*Created by: Fuuzetsu*

It can happen that RC restarts during bootstrap (HALON-226). This
meant that we could have already started processes and then re-entered
NewMeroServer handler from the beginning. We can deal fine with boot
level 0 mero-kernel but there was no real handling for processes
started directly on boot level 1. The fix/workaround is relatively
straight forward: don't start processes that we know have already been
started. There are a few gotchas with this:
- consider the scenario where every process has been started before
  rule restarted. We'd end up with no processes starting up so no
  notifications coming so bootstrap would look stuck. To deal with
  this we send ONLINE for the already started processes: it should
  have no adverse side-effects on mero and it will trigger cluster
  adjust rule in halon which can progress bootstrap.
- it only works in the common-case that we've seen, i.e. everything
  gets started OK. If process is in some other state, we don't have
  any sane handling. Everything may be OK still (not seen issue in
  practice) but we should have a more general fix (scoped under
  HALON-226).
