### PR TITLE
Add autobuild trigger as a deployment script

### DIFF
--- a/ci/autobuild.sh
+++ b/ci/autobuild.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set +x
+
+username="seagate-ssg"
+project="castor"
+branch="master"
+
+# See https://circleci.com/docs/api/#new-build and
+# https://circleci.com/docs/parameterized-builds/
+post_data=$(cat <<EOF
+{
+  "build_parameters": {
+    "SUBMODULE_UPDATE": "--remote",
+    "UPDATE_COMPONENTS": "true"
+  }
+}
+EOF
+)
+
+# Remark $CIRCLE_CI_TOKEN is typically populated in CIRCLE_CI's
+# project settings (environment variable tab) which stay secret.
+# NOTE: TODO
+curl \
+  --header "Content-Type: application/json" \
+  --data "${post_data}" \
+  --request POST \
+  https://circleci.com/api/v1/project/$username/$project/tree/$branch?circle-token=$CIRCLE_CI_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -69,3 +69,11 @@ test:
     - stack $STACK_FLAGS $STACK_TEST_FLAGS build --flag mero-halon:distributed-tests mero-halon:distributed-tests:
         timeout: 3600
     - scripts/copy_artifacts.sh "${CIRCLE_ARTIFACTS}"
+
+deployment:
+  # this deployment script will trigger the castor integration tests
+  # on the latest refs of the components.
+  autobuild:
+    branch: master
+    commands:
+      - bash ci/autobuild.sh


### PR DESCRIPTION
*Created by: aspiwack*

So that each green build on master will trigger a Castor build without
delay.

This is dependent on https://github.com/seagate-ssg/castor/pull/47 .

I've tested it as well as I could, but since it's a deployment script bound to the master branch, it is not impossible that some issue happen when it is merged into master.
