### PR TITLE
[HALON-170] Allow node revival on reboot

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Job.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Job.hs
@@ -18,11 +18,13 @@ module HA.RecoveryCoordinator.Actions.Job
 import HA.EventQueue.Types
 import HA.RecoveryCoordinator.Actions.Core
 
+import Control.Distributed.Process (say)
 import Control.Distributed.Process.Serializable
 import Control.Lens
 
 import Data.Foldable (for_)
 import Data.Proxy
+import qualified Data.Set as Set
 import Data.Vinyl
 
 import Network.CEP
@@ -65,7 +67,7 @@ mkJobRule (Job name)
       isRunning <- memberStorageSetRC input
       if isRunning
       then do
-         phaseLog "info" $ "Process " ++ name ++ " is already running, for " ++ show input
+         phaseLog "info" $ "Process " ++ name ++ " is already running for " ++ show input
          messageProcessed eid
       else
         check_input input >>= \case
@@ -95,4 +97,3 @@ mkJobRule (Job name)
     fldRequest = Proxy
     fldReply :: Proxy '("reply", Maybe output)
     fldReply = Proxy
-

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero.hs
@@ -98,16 +98,6 @@ timeoutHost h = hasHostAttr M0.HA_TRANSIENT h >>= \case
   False -> return ()
   True -> do
     liftProcess . sayRC $ "Disconnecting " ++ show h ++ " due to timeout"
-#ifdef USE_MERO
-    g <- getLocalGraph
-    let nodes = [ n
-                | (c :: M0.Controller) <- G.connectedFrom M0.At h g
-                , (n :: M0.Node) <- G.connectedFrom M0.IsOnHardware c g
-                ]
-    notifyMero $ createSet (M0.AnyConfObj <$> nodes) M0_NC_FAILED
-    -- TODO: do we also have to tell mero about things connected to
-    -- the nodes being down?
-#endif
     unsetHostAttr h M0.HA_TRANSIENT
     setHostAttr h M0.HA_DOWN
 

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Service.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Service.hs
@@ -281,6 +281,7 @@ serviceRules argv = do
                       ++ show count
                       ++ " attempts."
                        )
+
       selfMessage $ RecoverNode uuid n1
 
     start ph0 Nothing


### PR DESCRIPTION
*Created by: Fuuzetsu*

Notable changes
- ruleNodeNew is fixed to not get stuck (event messages are not
  replicated)
- A failed node rejoining cluster has its halon services disconnected
  and stored in RG then restarted after monitors are up (except m0d)
- After node-up is done, node bootstrap is executed
- Node without any boot level 0 processes sends out the barrier pass
  message so that it does not get stuck in case of restart: if it's
  the only node, nothing else would be sending this message.
- Time of node recovery increased (and recovery attempts adjusted). In
  practice nodes on cluster (dev1-1 at least) can take ~5 mins to go
  through a normal reboot. Not too happy with how this works: if node
  comes back after recovery rule gives up, it won't rejoin (doesn't
  send NodeUp). If we don't want to fail nodes forever, should rework
  this somehow.

---

Only tested with single node rebooting at once. Tested case of no boot level proceses on level 0 as well as case with processes on every level. Tested on node with m0t1fs (dd works after reboot) and without. Should add these tests to the test spreadsheet probably.
