### PR TITLE
HALON-321: Handle exceptions in predicates withing CEP.

### DIFF
--- a/cep/cep/src/Network/CEP.hs
+++ b/cep/cep/src/Network/CEP.hs
@@ -31,7 +31,6 @@ module Network.CEP
     , setPhase
     , setPhaseIf
     , setPhaseWire
-    , setPhaseMatch
     , setPhaseSequenceIf
     , setPhaseSequence
     , phaseHandle

--- a/cep/cep/src/Network/CEP/Types.hs
+++ b/cep/cep/src/Network/CEP/Types.hs
@@ -384,17 +384,6 @@ setPhaseWire :: (Serializable a, Serializable b)
              -> RuleM g l ()
 setPhaseWire h w action = singleton $ SetPhase h (ContCall (PhaseWire w) action)
 
--- | Assigns a 'PhaseHandle' to a 'Phase' state machine that would wait for
---   type of message to conform the given predicate in order to produce the
---   value needed to start.
-setPhaseMatch :: (Serializable a, Serializable b)
-              => Jump PhaseHandle
-              -> (a -> g -> l -> Process (Maybe b))
-              -> (b -> PhaseM g l ())
-              -> RuleM g l ()
-setPhaseMatch h p action =
-    singleton $ SetPhase h (ContCall (PhaseMatch p) action)
-
 -- | Internal use only. Waits for 2 type of messages to come sequentially and
 --   apply them to a predicate. If the predicate is statisfied, we yield those
 --   value in a tuple, otherwise we switch to the 'Error' state.


### PR DESCRIPTION
*Created by: qnikst*

Now CEP have following semantics: if any synchronous exception
(e.g. pattern match failure) occurs when executing phase predicate
this will mean fail of predicate. And no exception will be thrown.

Possibly this semantics will be a subject of change and some
exceptions, other than pattern match failure, will lead to rule
removal in future.
