### PR TITLE
[HALON-322] Proper M0Node lookup for mero client nodes

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Hardware.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Hardware.hs
@@ -245,11 +245,12 @@ hasHostAttr :: HostAttr
             -> Host
             -> PhaseM LoopState l Bool
 hasHostAttr f h = do
-  phaseLog "rg-query" $ "Checking host "
+  g <- getLocalGraph
+  let result = G.isConnected h Has f g
+  phaseLog "rg-query" $ "Checking "
                       ++ show h
                       ++ " for attribute "
-                      ++ show f
-  g <- getLocalGraph
+                      ++ show f ++ ": " ++ show result
   return $ G.isConnected h Has f g
 
 -- | Set an attribute on a host. Note that this will not replace


### PR DESCRIPTION
*Created by: Fuuzetsu*

Previously we always went through controller but client nodes are not
attached to any controllers. This meant we would not find the relevant
m0node, would not set it to transient and its processes to inhibited
and therefore would not try to restart procesess when the node came
back.

Also minor logging changes.

---

Verified to work by Andriy
