### PR TITLE
[HALON-325] Continue teardown even when process stop times out

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Process.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Process.hs
@@ -387,7 +387,7 @@ ruleProcessControlStop = defineSimpleTask "handle-process-stop" $ \(ProcessContr
   forM_ (rights results) $ \(x,s) ->
     phaseLog "error" $ printf "failed to stop service %s : %s" (show x) s
   forM_ (lefts results) $ \x ->
-    phaseLog "error" $ printf "process started: %s" (show x)
+    phaseLog "info" $ printf "process stopped: %s" (show x)
 
 -- | Listens for 'NotifyFailureEndpoints' from notification mechanism.
 -- Finds the non-failed processes which failed to be notified (through


### PR DESCRIPTION
*Created by: Fuuzetsu*

Tested by simulating a timeout on VM, Andriy's cluster down for upgrades right now but I trust it should work there too (will try once available)
