### PR TITLE
rpclite/m0init: set m0init_hi to NULL if initialisation fails

### DIFF
--- a/rpclite/rpclite/m0init.c
+++ b/rpclite/rpclite/m0init.c
@@ -15,6 +15,7 @@ struct m0_halon_interface* m0init_hi = NULL;
 int m0_init_wrapper () {
     const struct m0_build_info* bi = m0_build_info_get();
     int disable_compat_check = getenv("DISABLE_MERO_COMPAT_CHECK") == NULL;
+    int rc;
     if (0 != strcmp(bi->bi_git_rev_id, M0_VERSION_GIT_REV_ID)) {
       fprintf(stderr, "m0_init_wrapper: The loaded mero library (%s) "
                       "is not the expected one (%s)\n"
@@ -38,7 +39,12 @@ int m0_init_wrapper () {
     }
     M0_ASSERT(m0init_hi == NULL);
     m0init_hi = (struct m0_halon_interface*)calloc(1, sizeof(struct m0_halon_interface));
-    return m0_halon_interface_init(m0init_hi, M0_VERSION_GIT_REV_ID, M0_VERSION_BUILD_CONFIGURE_OPTS, disable_compat_check);
+    rc = m0_halon_interface_init(m0init_hi, M0_VERSION_GIT_REV_ID, M0_VERSION_BUILD_CONFIGURE_OPTS, disable_compat_check);
+    if (rc != 0) {
+	    free(m0init_hi);
+	    m0init_hi = NULL;
+    }
+    return rc;
 }
 
 void m0_fini_wrapper() {


### PR DESCRIPTION
*Created by: mmedved*

Subsequent initialisation crashes with assertion failure otherwise.
