### PR TITLE
Halon-402: Update how we handle transient failures.

### DIFF
--- a/mero-halon/src/lib/HA/Resources/Mero.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero.hs
@@ -347,8 +347,6 @@ prettySDevState (SDSTransient x) = "Transient failure (" ++ prettySDevState x ++
 --   where the device is failed or already transient.
 sdsFailTransient :: SDevState -> SDevState
 sdsFailTransient SDSFailed = SDSFailed
-sdsFailTransient SDSRepairing = SDSRepairing
-sdsFailTransient SDSRepaired = SDSRepaired
 sdsFailTransient s@(SDSTransient _) = s
 sdsFailTransient x = SDSTransient x
 

--- a/mero-halon/src/lib/HA/Resources/Mero/Note.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero/Note.hs
@@ -288,6 +288,9 @@ instance HasConfObjectState M0.SDev where
   toConfObjState _ M0.SDSRepaired = M0_NC_REPAIRED
   toConfObjState _ M0.SDSRebalancing = M0_NC_REBALANCE
   toConfObjState _ (M0.SDSTransient M0.SDSFailed) = M0_NC_FAILED -- odd case
+  toConfObjState _ (M0.SDSTransient M0.SDSRepairing) = M0_NC_REPAIR
+  toConfObjState _ (M0.SDSTransient M0.SDSRepaired) = M0_NC_REPAIRED
+  toConfObjState _ (M0.SDSTransient M0.SDSRebalancing) = M0_NC_REBALANCE
   toConfObjState _ (M0.SDSTransient _) = M0_NC_TRANSIENT
 instance HasConfObjectState M0.Pool where
   hasStateDict = staticPtr $ static dict_HasConfObjectState_Pool


### PR DESCRIPTION
*Created by: nc6*

During repair/rebalance, we should mark transient
appropriately but display the underlying state to
Mero.
