### PR TITLE
[HALON-395] Do not start repair unless IOS are ready

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Spiel.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Spiel.hs
@@ -151,7 +151,8 @@ startRepairOperation pool = go `catch`
     )
   where
     go = do
-      phaseLog "spiel" $ "Starting repair on pool " ++ show pool
+      phaseLog "spiel" $ "Starting repair operation."
+      phaseLog "pool"  $ show pool
       _ <- withSpielRC $ \sc lift -> withRConfRC sc $ lift $ poolRepairStart sc (M0.fid pool)
       uuid <- DP.liftIO nextRandom
       setPoolRepairStatus pool $ M0.PoolRepairStatus M0.Failure uuid Nothing
@@ -507,7 +508,7 @@ txPopulate lift (TxConfData CI.M0Globals{..} (M0.Profile pfid) fs@M0.Filesystem{
   let pools = G.connectedTo fs M0.IsParentOf g :: [M0.Pool]
       pvNegWidth pver = case pver of
                          M0.PVer _ a@M0.PVerActual{}    -> negate . _pa_P . M0.v_attrs $ a
-                         M0.PVer _ a@M0.PVerFormulaic{} -> 0
+                         M0.PVer _ M0.PVerFormulaic{} -> 0
   for_ pools $ \pool -> do
     lift $ addPool t (M0.fid pool) f_fid 0
     let pvers = sortOn pvNegWidth $ G.connectedTo pool M0.IsRealOf g :: [M0.PVer]

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Castor/Cluster.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Castor/Cluster.hs
@@ -14,7 +14,9 @@ module HA.RecoveryCoordinator.Events.Castor.Cluster
   , StartMeroClientRequest(..)
   , StateChangeResult(..)
   , PoolRebalanceRequest(..)
+  , PoolRebalanceStarted(..)
   , PoolRepairRequest(..)
+  , PoolRepairStarted(..)
   , ClusterResetRequest(..)
     -- ** Node
   , StartCastorNodeRequest(..)
@@ -83,10 +85,16 @@ data StateChangeResult
 instance Binary StateChangeResult
 
 newtype PoolRebalanceRequest = PoolRebalanceRequest M0.Pool
-  deriving (Eq, Show, Binary, Typeable, Generic)
+  deriving (Eq, Show, Ord, Binary, Typeable, Generic)
+
+newtype PoolRebalanceStarted = PoolRebalanceStarted M0.Pool
+  deriving (Show, Eq, Ord, Binary, Typeable, Generic)
 
 newtype PoolRepairRequest = PoolRepairRequest M0.Pool
-  deriving (Eq, Show, Binary, Typeable, Generic)
+  deriving (Eq, Show, Ord, Binary, Typeable, Generic)
+
+newtype PoolRepairStarted = PoolRepairStarted M0.Pool
+  deriving (Show, Eq, Ord, Binary, Typeable, Generic)
 
 -- | Internal event sent when the cluster changes state.
 data ClusterStateChange =


### PR DESCRIPTION
*Created by: Fuuzetsu*

Take care to keep drives in sane state so that:
- before IOS comes back, it doesn't look like we're repairing the drives
- after IOS comes back, it's able to perform the repair
