### PR TITLE
[HALON-419] Run recovery for rejoining nodes

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/CEP.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/CEP.hs
@@ -261,6 +261,9 @@ ruleRecoverNode argv = mkJobRule recoverJob args $ \finish -> do
               False -> do
                 setHostAttr host M0.HA_TRANSIENT
 #ifdef USE_MERO
+                -- ideally we would like to unregister this when
+                -- monitor disconnects and not here: what if node came
+                -- back before recovery fired? unlikely but who knows
                 case nodeToM0Node n1 g of
                   [] -> phaseLog "warn" $ "Couldn't find any mero nodes for " ++ show n1
                   ns -> applyStateChanges $ (\n -> stateSet n NSFailed) <$> ns
@@ -402,4 +405,3 @@ sendLogs logs ls = do
                 , n <- G.connectedTo host Runs rg :: [Node]
                 , not . null $ lookupServiceInfo n decisionLog rg
                 ]
-

--- a/mero-halon/src/lib/HA/Services/Mero/RC/Actions.hs
+++ b/mero-halon/src/lib/HA/Services/Mero/RC/Actions.hs
@@ -102,6 +102,7 @@ lookupMeroChannelByNode node = do
 -- | Unregister all channels.
 unregisterMeroChannelsOn :: R.Node -> PhaseM LoopState l ()
 unregisterMeroChannelsOn node = do
+   phaseLog "info" $ "Unregistering mero channels on " ++ show node
    unregisterChannel node (Proxy :: Proxy NotificationMessage)
    unregisterChannel node (Proxy :: Proxy ProcessControlMsg)
 


### PR DESCRIPTION
*Created by: Fuuzetsu*

Make sure to wait for halon:m0d to come back and be ready before
trying to start other processes.

---

on dev2-1 with client: halon does right thing but m0t1fs fails to restart due to mero issue; max is on it as part of reconnect
on dev1-1: recovery fails to reconnect to ssu8, don't know why but perhaps I restarted halond wrong there; works great with ssu6
