### PR TITLE
[HALON-429] Fix drive status check in SNS rules.

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Drive/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Drive/Rules.hs
@@ -317,7 +317,7 @@ ruleDriveInserted = define "drive-inserted" $ do
          let markIfNotMeroFailure = do
                -- TODO this should be more general and should check for
                -- e.g. smart failure as well.
-               let isMeroFailure (StorageDeviceStatus "MERO-FAILED" _) = True
+               let isMeroFailure (StorageDeviceStatus "HALON-FAILED" _) = True
                    isMeroFailure _ = False
                meroFailure <- maybe False isMeroFailure <$> driveStatus disk
                if meroFailure
@@ -506,7 +506,7 @@ ruleDrivePoweredOn = define "drive-powered-on" $ do
   where
     filterMaybeM _ Nothing = return Nothing
     filterMaybeM f j@(Just x) = f x >>= \q -> return $ if q then j else Nothing
-    isRealFailure (StorageDeviceStatus "MERO-FAILED" _) = True
+    isRealFailure (StorageDeviceStatus "HALON-FAILED" _) = True
     isRealFailure (StorageDeviceStatus "FAILED" _) = True
     isRealFailure _ = False
     m0failed SDSFailed = True


### PR DESCRIPTION
*Created by: qnikst*

Change halon to check SNS "HALON-FAILED" status, to see if
drive was marked as permanently broken by halon.

[risk-assement] Code in question is does not affect
other block of the node. However testing may become harder
because some use cases could rely on old broken logic.

[risk-code] The changes in code are minor and should not
affect quality.

X-REQUEST-TYPE: Developement requested
X-RESOLVE-A200: Yes
X-RISK-DEFECT: Low
X-RISK-CODE: Low
X-BLOCKER: No
X-NEW-FEATURE: No
