### PR TITLE
HALON-424 Node should reply on client started even.

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Node.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Node.hs
@@ -796,7 +796,11 @@ ruleStartClientsOnNode = mkJobRule processStartClientsOnNode args $ \finish -> d
           phaseLog "info" $ "Configuring mero client on " ++ show host
           procs <- configureNodeProcesses host chan M0.PLM0t1fs False
           if null procs
-          then continue finish
+          then do
+            Just m0node <- getField . rget fldM0Node <$> get Local
+            modify Local $ rlens fldRep . rfield .~
+              (Just $ ClientsStartOk m0node)
+            continue finish
           else do
             modify Local $ rlens fldProcessConfig . rfield .~
               (Just $ M0.fid <$> procs)


### PR DESCRIPTION
*Created by: qnikst*

If node was asked to start a client on it, it should reply
even if there are no clients. This is needed because requestor
could be waiting for reply.
