### PR TITLE
[HALON-437] Improve notification mechanism.

### DIFF
--- a/mero-halon/src/lib/HA/Services/Mero/RC/Actions.hs
+++ b/mero-halon/src/lib/HA/Services/Mero/RC/Actions.hs
@@ -119,7 +119,6 @@ getNotificationChannels = do
   things <- for nodes $ \(node, m0node) -> do
      mchan <- lookupMeroChannelByNode node
      let procs = filter (\p -> case M0.getState p rg of
-                                 M0.PSUnknown -> True
                                  M0.PSOnline  -> True
                                  M0.PSStarting -> True
                                  M0.PSStopping -> True

--- a/mero-halon/src/lib/HA/Services/Mero/RC/Rules.hs
+++ b/mero-halon/src/lib/HA/Services/Mero/RC/Rules.hs
@@ -91,6 +91,8 @@ ruleNotificationsDeliveredToM0d = defineSimpleTask "service::m0d::notification::
 ruleNotificationsFailedToBeDeliveredToM0d :: Definitions LoopState ()
 ruleNotificationsFailedToBeDeliveredToM0d = defineSimpleTask "service::m0d::notification::delivery-failed" $
   \(NotificationFailure epoch fid) -> do
+      phaseLog "epoch" $ show epoch
+      phaseLog "fid"   $ show fid
       mdiff <- getStateDiffByEpoch epoch
       for_ mdiff $ \diff -> do
         mp <- M0.lookupConfObjByFid fid <$> getLocalGraph


### PR DESCRIPTION
*Created by: qnikst*

Output more information when notification failed to be delivered
to mero, e.g. output process fid and epoch.

Do not send message to processes that are in undefined state.
Currently undefined state is an initial state, it means that
process is not running, so seding message to such process leads
to round of the delivery-failed notifications.
