### PR TITLE
[HALON-434] Re-order notifications for mero

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -182,6 +182,7 @@ Library
                        HA.Resources.Mero
                        HA.Resources.Mero.Note
                        HA.Services.Mero
+                       HA.Services.Mero.RC.Actions
                        HA.Services.Mero.Types
                        HA.RecoveryCoordinator.Actions.Castor
                        HA.RecoveryCoordinator.Actions.Castor.Cluster
@@ -197,7 +198,6 @@ Library
                        HA.RecoveryCoordinator.Rules.Castor.Process.Keepalive
                        HA.RecoveryCoordinator.Events.Mero
                        HA.Services.Mero.RC
-
       Other-Modules:
                       HA.RecoveryCoordinator.Actions.Mero.Spiel
                       HA.RecoveryCoordinator.Castor.Drive.Actions
@@ -211,7 +211,6 @@ Library
                       HA.RecoveryCoordinator.Rules.Castor.Node
                       HA.RecoveryCoordinator.Rules.Castor.Expander
                       HA.Resources.Mero.Note.TH
-                      HA.Services.Mero.RC.Actions
                       HA.Services.Mero.RC.Rules
                       HA.Services.Mero.RC.Events
                       HA.Services.Mero.RC.Resources
@@ -535,6 +534,7 @@ Test-Suite tests
                     HA.Test.Cluster
                     HA.Test.Disconnect
                     HA.Test.InternalStateChanges
+                    HA.Test.NotificationSort
                     HA.Test.SSPL
                     Helper.SSPL
                     RemoteTables

--- a/mero-halon/src/lib/HA/Resources/Mero.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero.hs
@@ -97,8 +97,19 @@ fidIsType :: ConfObj a
           => Proxy a
           -> Fid
           -> Bool
-fidIsType p (Fid ctr _) =
-  (ctr .&. (complement typMask)) == (fidType p `shiftL` (64 - 8))
+fidIsType p fid' = fidToFidType fid' == confToFidType p
+
+-- | Like 'fidType' but shifted which allows for a much easier
+-- comparison of proxy fid types with raw 'Fid's.
+confToFidType :: ConfObj a => Proxy a -> Word64
+confToFidType p = fidType p `shiftL` (64 - 8)
+
+-- | Take a raw 'Fid' and extract the the type.
+-- Useful when the container may have been poluted with extra
+-- information such as through 'fidInit'.
+fidToFidType :: Fid -> Word64
+fidToFidType (Fid ctr _) = ctr .&. complement typMask
+
 
 data AnyConfObj = forall a. ConfObj a => AnyConfObj a
   deriving (Typeable)

--- a/mero-halon/tests/HA/Test/NotificationSort.hs
+++ b/mero-halon/tests/HA/Test/NotificationSort.hs
@@ -1,0 +1,81 @@
+-- |
+-- Copyright : (C) 2016 Seagate Technology Limited.
+-- License   : All rights reserved.
+--
+-- Test the NVec notification sorting mechanism.
+module HA.Test.NotificationSort (tests) where
+
+import Data.Proxy
+import GHC.Word (Word64)
+import HA.Resources.Mero as M0
+import HA.Resources.Mero.Note (ConfObjectState(..))
+import HA.Services.Mero.RC.Actions (orderSet)
+import Mero.ConfC (Fid)
+import Mero.Notification (Set(..))
+import Mero.Notification.HAState (Note(..))
+import Test.Framework
+import Test.Tasty.HUnit (assertEqual)
+
+tests :: [TestTree]
+tests = [ testSuccess "sortsInteresting" sortsInteresting
+        , testSuccess "sortsUninteresting" sortsUninteresting
+        ]
+
+mkN :: [Fid] -> Set
+mkN = Set . map (\fid' -> Note fid' M0_NC_ONLINE)
+
+-- | Sorts interesting things in correct order and puts un-interesting
+-- thing in the back
+sortsInteresting :: IO ()
+sortsInteresting = do
+  assertEqual "Sorts interesting" (orderSet ordering $ mkN startSet) (mkN stopSet)
+  where
+    startSet :: [Fid]
+    startSet = [ M0.fid $ M0.Enclosure (M0.fidInit (Proxy :: Proxy M0.Enclosure) 1 2)
+               , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 3)
+               , M0.fid $ M0.Enclosure (M0.fidInit (Proxy :: Proxy M0.Enclosure) 1 1)
+               , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 1)
+               , M0.fid $ M0.RackV (M0.fidInit (Proxy :: Proxy M0.RackV) 1 1)
+               , M0.fid $ M0.Disk (M0.fidInit (Proxy :: Proxy M0.Disk) 1 1)
+               , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 2)
+               ]
+
+    stopSet :: [Fid]
+    stopSet = [ M0.fid $ M0.Disk (M0.fidInit (Proxy :: Proxy M0.Disk) 1 1)
+              , M0.fid $ M0.Enclosure (M0.fidInit (Proxy :: Proxy M0.Enclosure) 1 1)
+              , M0.fid $ M0.Enclosure (M0.fidInit (Proxy :: Proxy M0.Enclosure) 1 2)
+              , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 1)
+              , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 2)
+              , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 3)
+              , M0.fid $ M0.RackV (M0.fidInit (Proxy :: Proxy M0.RackV) 1 1)
+              ]
+
+    ordering :: [Word64]
+    ordering = [ M0.confToFidType (Proxy :: Proxy M0.Disk)
+               , M0.confToFidType (Proxy :: Proxy M0.Enclosure)
+               , M0.confToFidType (Proxy :: Proxy M0.Controller)
+               ]
+
+-- | Sorts uninteresting things
+sortsUninteresting :: IO ()
+sortsUninteresting = do
+  assertEqual "Sorts uninteresting" (orderSet ordering $ mkN startSet) (mkN stopSet)
+  where
+    startSet :: [Fid]
+    startSet = [ M0.fid $ M0.Enclosure (M0.fidInit (Proxy :: Proxy M0.Enclosure) 1 2)
+               , M0.fid $ M0.Enclosure (M0.fidInit (Proxy :: Proxy M0.Enclosure) 1 1)
+               , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 3)
+               , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 1)
+               , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 2)
+               ]
+
+    stopSet :: [Fid]
+    stopSet = [ M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 1)
+              , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 2)
+              , M0.fid $ M0.Controller (M0.fidInit (Proxy :: Proxy M0.Controller) 1 3)
+              , M0.fid $ M0.Enclosure (M0.fidInit (Proxy :: Proxy M0.Enclosure) 1 1)
+              , M0.fid $ M0.Enclosure (M0.fidInit (Proxy :: Proxy M0.Enclosure) 1 2)
+              ]
+
+    ordering :: [Word64]
+    ordering = []

--- a/mero-halon/tests/tests.hs
+++ b/mero-halon/tests/tests.hs
@@ -12,6 +12,7 @@ import qualified HA.Autoboot.Tests
 #ifdef USE_MERO
 import qualified HA.RecoveryCoordinator.SSPL.Tests
 import qualified HA.Test.InternalStateChanges
+import qualified HA.Test.NotificationSort
 import qualified HA.Castor.Story.ProcessRestart
 import qualified HA.Castor.Tests
 import qualified HA.Castor.Story.Tests
@@ -89,6 +90,8 @@ ut _host transport _breakConnection = do
                  , HA.RecoveryCoordinator.SSPL.Tests.utTests transport pg
                  , [testCase "Ignore me" $ return ()]
                  )
+      , MERO_TEST( testGroup, "NotificationSort", HA.Test.NotificationSort.tests
+                 , [testCase "ignore me" $ return ()])
       ]
 
 it :: String -> Transport -> (EndPointAddress -> EndPointAddress -> IO ()) -> IO TestTree
@@ -134,7 +137,7 @@ it _host transport breakConnection = do
 -- | Set up a 'Transport' and a way to break connections before
 -- passing it off to the given test tree.
 runTests :: (String -> Transport -> (EndPointAddress -> EndPointAddress -> IO ()) -> IO TestTree) -> IO ()
-runTests tests = do
+runTests tests' = do
     -- TODO: Remove threadDelay after RPC transport closes cleanly
     hSetBuffering stdout LineBuffering
     hSetBuffering stderr LineBuffering
@@ -169,7 +172,7 @@ runTests tests = do
             TCP.socketBetween internals there here >>= TCP.close
 #endif
     defaultMainWithIngredients [fileTestReporter [consoleTestReporter]]
-      =<< tests host0 transport connectionBreak
+      =<< tests' host0 transport connectionBreak
 
 main :: IO ()
 main = prepare $ runTests tests where


### PR DESCRIPTION
*Created by: Fuuzetsu*

Mero requires that controller information is put earlier in nvec than
disk/sdev info to function properly.
