### PR TITLE
[HALON-441] Handle process restart exit codes

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Castor/Process.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Castor/Process.hs
@@ -5,12 +5,14 @@
 -- License   : All rights reserved.
 module HA.RecoveryCoordinator.Events.Castor.Process
   ( ProcessRecoveryFailure(..)
+  , ProcessRestartRequest(..)
   ) where
 
 import           Data.Binary
 import           Data.Hashable
 import           Data.Typeable
 import           GHC.Generics
+import qualified HA.Resources.Mero as M0
 import           Mero.ConfC (Fid)
 
 -- | Event is arrived in case if recovery failed, this event goes
@@ -20,3 +22,7 @@ newtype ProcessRecoveryFailure = ProcessRecoveryFailure (Fid, String)
 
 instance Binary ProcessRecoveryFailure
 instance Hashable ProcessRecoveryFailure
+
+newtype ProcessRestartRequest = ProcessRestartRequest M0.Process
+  deriving (Show, Eq, Ord, Typeable, Generic)
+instance Binary ProcessRestartRequest


### PR DESCRIPTION
*Created by: Fuuzetsu*

This actually has a wider impact that expected. Since some time
recently, we are actually no longer `start`ing processes but always
`restart`ing them: this is because we set process to starting state
before calling `startMeroProcesses`. It just happened to be OK but it
means that failures would have gone uncaught.

The main change in this PR is that `ruleProcessRestart` now does less:
it no longer explicitly tries to fail services associated with the
process. This rule is most often triggered through a process failed
internal state change notification and if we're receiving that then
cascade would have already failed services as well. This allows us to
use `ruleProcessRestart` as a much more friendly rule to invoke from
other places and to get out process restart timeout and result message
handling that it offers out of it.
