### PR TITLE
HALON-444: Don't mark already FAILED disk as HALON-failed.

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Drive/Rules/Reset.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Drive/Rules/Reset.hs
@@ -127,7 +127,7 @@ handleResetExternal (Set ns) = do
                       -- We handle this status inside external rule, because we need to
                       -- update drive manager if and only if failure is set because of
                       -- mero notifications, not because drive removal or other event.
-                      when (status == M0.SDSFailed) $ do
+                      when (ratt > resetAttemptThreshold) $ do
                         phaseLog "warning" "drive have failed to reset too many times => making as failed."
                         updateDriveManagerWithFailure sdev "HALON-FAILED" (Just "MERO-Timeout")
 


### PR DESCRIPTION
*Created by: nc6*

HALON-failed is a "protected" state to SSPL - it will not be
overridden. We only set it when we have inferred a failure from
a non-SSPL channel, such as Mero. It was possible for it to be set
on an SSPL-informed failure due to a race with Mero notifications.
This patch updates the check such that it will only be set after
repeated reset attempts.
