### PR TITLE
[HALON-448] Tread IDLE reply on SNS status as a final state.

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Spiel.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero/Spiel.hs
@@ -365,7 +365,9 @@ mkRepairQuiesceOperation =
     (Proxy :: Proxy "Repair quiesce")
     mkRepairStatusRequestOperation
     poolRepairQuiesce
-    [Mero.Spiel.M0_SNS_CM_STATUS_FAILED,Mero.Spiel.M0_SNS_CM_STATUS_PAUSED]
+    [ Mero.Spiel.M0_SNS_CM_STATUS_FAILED
+    , Mero.Spiel.M0_SNS_CM_STATUS_PAUSED
+    , Mero.Spiel.M0_SNS_CM_STATUS_IDLE]
 
 -- | Create an action and helper phases that will allow to abort SNS operation
 -- and wait until it will be really aborted.
@@ -394,7 +396,9 @@ mkRebalanceQuiesceOperation = do
     (Proxy :: Proxy "Rebalance quiesce")
     mkRebalanceStatusRequestOperation
     poolRebalanceQuiesce
-    [Mero.Spiel.M0_SNS_CM_STATUS_FAILED,Mero.Spiel.M0_SNS_CM_STATUS_PAUSED]
+    [ Mero.Spiel.M0_SNS_CM_STATUS_FAILED
+    , Mero.Spiel.M0_SNS_CM_STATUS_PAUSED
+    , Mero.Spiel.M0_SNS_CM_STATUS_IDLE]
 
 -- | Generate code to call abort operation.
 mkRebalanceAbortOperation ::


### PR DESCRIPTION
*Created by: qnikst*

After repair/rebalance quiesce halon will start query SNS state
until all IOS will be in the final state. Previously only
FAILED and PAUSED states were considered as final. Now we do
the same for the IDLE. In this case SNS operation will be aborted.
