### PR TITLE
[HALON-445] Restart rebalance if disk reattached

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Hardware.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Hardware.hs
@@ -513,13 +513,12 @@ updateDriveStatus :: StorageDevice
                   -> String -- ^ Reason.
                   -> PhaseM LoopState l ()
 updateDriveStatus dev status reason = modifyLocalGraph $ \rg -> do
-  phaseLog "rg" $ "Updating status for device"
-  phaseLog "status" $ status
-  phaseLog "reason" $ reason
   ds <- driveStatus dev
-  phaseLog "rg" $ "Old status was " ++ show ds
   let statusNode = StorageDeviceStatus status reason
-      rg' = G.newResource statusNode
+  phaseLog "rg" $ "Updating status for device"
+  phaseLog "status.old" $ show ds
+  phaseLog "status.new" $ show statusNode
+  let rg' = G.newResource statusNode
         >>> G.connectUniqueFrom dev Is statusNode
           $ rg
   return rg'

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Mero.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Mero.hs
@@ -188,13 +188,15 @@ data MeroKernelFailed = MeroKernelFailed ProcessId String
 
 instance Binary MeroKernelFailed
 
-
 newtype NodeKernelFailed = NodeKernelFailed M0.Node
   deriving (Eq, Show, Typeable, Generic, Binary)
 
--- | Request abort on the given pool.
-newtype AbortSNSOperation = AbortSNSOperation M0.Pool
-  deriving (Eq, Show, Ord, Typeable, Generic, Binary)
+-- | Request abort on the given pool. If 'UUID' is provided, only
+-- abort if the pool repair status has the Poolgiven 'UUID'
+data AbortSNSOperation = AbortSNSOperation M0.Pool UUID
+  deriving (Eq, Show, Ord, Typeable, Generic)
+
+instance Binary AbortSNSOperation
 
 -- | Reply to SNS operation abort.
 data AbortSNSOperationResult

--- a/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
@@ -183,7 +183,7 @@ parseControlState t
 halonPriority :: Int
 halonPriority = 7
 
--- | Convert @NodeCmd@ to text represetnation.
+-- | Convert @NodeCmd@ to text representation.
 nodeCmdString :: NodeCmd -> T.Text
 nodeCmdString (IPMICmd op ip) = T.intercalate " "
   [ "IPMI:", ip, ipmiOpString op ]


### PR DESCRIPTION
*Created by: Fuuzetsu*

It may happen that more than one drive fails. For example we detach two
drives, repair happens, rebalance starts. During rebalance, we may
attach one of the drives back and the drive may be just fine. In this
case rebalance might have proceeded "too far" already and skipped over
the drive as it was failed at the time.

To make sure all online drives are taken care of during rebalance, if a
drive is attached during it, just abort and start it again.

---

This is pretty hard to test: you have to time SMART repair to finish after rebalance is started by another drive, not before nor after; difficult on cluster at best. I think we could write a test for this that just sends the messages for mock disks and sees what happens.
