### PR TITLE
[HALON-464] Don't drop logs in presence of fork

### DIFF
--- a/cep/cep/src/Network/CEP/Phase.hs
+++ b/cep/cep/src/Network/CEP/Phase.hs
@@ -244,7 +244,7 @@ runPhaseM pname subs plogs idx pl mindex pb action = consume [(idx, (pb,pl,actio
                       NoBuffer -> emptyFifoBuffer
                       CopyBuffer -> buf
                       CopyNewerBuffer -> maybe buf (`bufferDrop` buf) mindex
-          in do ((b', out), sm, s) <- go l (fmap (const S.empty) lgs) buf (k ())
+          in do ((b', out), sm, s) <- go l lgs buf (k ())
                 return ((b', out), (buf',l,naction):sm, s)
         inner (Lift m :>>= k) = do
           a' <- lift m

--- a/cep/cep/src/Network/CEP/Types.hs
+++ b/cep/cep/src/Network/CEP/Types.hs
@@ -614,7 +614,7 @@ data Logs =
       -- ^ Rule name associated with those logs.
     , logsPhaseEntries :: ![(String, String, String)]
       -- ^ Each entry is compound of 'Phase' name, a context and a log value.
-    } deriving (Show, Typeable, Generic)
+    } deriving (Eq, Show, Typeable, Generic)
 
 instance Binary Logs
 


### PR DESCRIPTION
*Created by: Fuuzetsu*

Should get rid of phantom missing logs in things like Halon's PoolRebalanceRequest handler &c.
