### PR TITLE
[HALON-466] Fix problem during initial data configuration.

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor.hs
@@ -84,7 +84,6 @@ ruleInitialDataLoad = defineSimple "castor::initial-data-load" $ \(HAEvent eid C
   if null racks
   then do
       mapM_ goRack id_racks
-      syncGraphBlocking
 #ifdef USE_MERO
       (do filesystem <- initialiseConfInRG
           loadMeroGlobals id_m0_globals


### PR DESCRIPTION
*Created by: qnikst*

It appeared that halon did graph synchronization before
configuration was totally validated, this could lead to
a problem when after loading broken initial data it would
not be able to load correct one.
