### PR TITLE
[HALON-438] Improve hctl cluster stop command

### DIFF
--- a/mero-halon/src/lib/HA/Resources/Mero.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero.hs
@@ -297,6 +297,9 @@ data Service = Service {
   , s_params :: ServiceParams
 } deriving (Eq, Generic, Show, Typeable)
 
+instance Ord Service where
+  compare = comparing s_fid
+
 instance Binary Service
 instance Hashable Service
 instance ToJSON Service


### PR DESCRIPTION
*Created by: Fuuzetsu*

Made the command synchronous by default. Added async, silent and (hctl)
timeout flags. Added progress reporting.

Sample run from devvm:

```
+ sudo /home/vagrant/halon-clean/.stack-work/install/x86_64-linux/lts-5.17/7.10.3/bin/halonctl -l 10.0.2.15:9010 -a 10.0.2.15:9000 cluster status
Cluster is Disposition: ONLINE
Current run level: 2
Current stop level: 2

  cluster info:
    profile:    0x7000000000000001:0x1
    filesystem: 0x6600000000000001:0x4
Hosts:
  devvm.seagate.com ==> 0x6e00000000000001:0x7  [online]
    [online]    10.0.2.15@tcp:12345:41:201  mdservice   ==> 0x7200000000000001:0x1f
        [online]    CST_ADDB2           ==> 0x7300000000000001:0x22
        [online]    CST_RMS         ==> 0x7300000000000001:0x20
        [online]    CST_MDS         ==> 0x7300000000000001:0x21
    [online]    10.0.2.15@tcp:12345:41:401  ioservice   ==> 0x7200000000000001:0x23
        [online]    CST_RMS         ==> 0x7300000000000001:0x24
        [online]    CST_IOS         ==> 0x7300000000000001:0x25
        [online]    CST_ADDB2           ==> 0x7300000000000001:0x28
        [online]    CST_SNS_REP         ==> 0x7300000000000001:0x26
        [online]    CST_SNS_REB         ==> 0x7300000000000001:0x27
    [online]    10.0.2.15@tcp:12345:34:101  halon       ==> 0x7200000000000001:0x1c
        [online]    CST_RMS         ==> 0x7300000000000001:0x1e
        [online]    CST_HA          ==> 0x7300000000000001:0x1d
    [online]    10.0.2.15@tcp:12345:44:101  confd       ==> 0x7200000000000001:0x19
        [online]    CST_RMS         ==> 0x7300000000000001:0x1b
        [online]    CST_MGS         ==> 0x7300000000000001:0x1a
    [starting]  10.0.2.15@tcp:12345:41:301  m0t1fs      ==> 0x7200000000000001:0x29
        [starting]  CST_RMS         ==> 0x7300000000000001:0x2a
+ COMMAND=
+ getopts 'h?sc:' opt
+ shift 2
[vagrant@devvm tmp]$ /home/vagrant/halon-clean/.stack-work/install/x86_64-linux/lts-5.17/7.10.3/bin/halonctl -l 10.0.2.15:9001 -a 10.0.2.15:9000 cluster stop
Stopping cluster.
StateChangeStarted pid://10.0.2.15:9000:0:57
Process{0x7200000000000001:0x29}: PSQuiescing -> PSOffline
Service{0x7300000000000001:0x2a}: SSInhibited SSOnline -> SSOffline
Progress: 5.26% -> 15.79%
Process{0x7200000000000001:0x1f}: PSQuiescing -> PSOffline
Process{0x7200000000000001:0x23}: PSQuiescing -> PSOffline
Service{0x7300000000000001:0x22}: SSInhibited SSOnline -> SSOffline
Service{0x7300000000000001:0x20}: SSInhibited SSOnline -> SSOffline
Service{0x7300000000000001:0x21}: SSInhibited SSOnline -> SSOffline
Service{0x7300000000000001:0x24}: SSInhibited SSOnline -> SSOffline
Service{0x7300000000000001:0x25}: SSInhibited SSOnline -> SSOffline
Service{0x7300000000000001:0x28}: SSInhibited SSOnline -> SSOffline
Service{0x7300000000000001:0x26}: SSInhibited SSOnline -> SSOffline
Service{0x7300000000000001:0x27}: SSInhibited SSOnline -> SSOffline
Progress: 15.79% -> 68.42%
Process{0x7200000000000001:0x19}: PSQuiescing -> PSOffline
Service{0x7300000000000001:0x1b}: SSInhibited SSOnline -> SSOffline
Service{0x7300000000000001:0x1a}: SSInhibited SSOnline -> SSOffline
Progress: 68.42% -> 84.21%
Process{0x7200000000000001:0x1c}: PSOnline -> PSOffline
Service{0x7300000000000001:0x1e}: SSOnline -> SSOffline
Service{0x7300000000000001:0x1d}: SSOnline -> SSOffline
Progress: 84.21% -> 100.00%
Cluster stopped successfully
```
