### PR TITLE
[HALON-493] Always wipe drive reset marker

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Drive/Events.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Drive/Events.hs
@@ -15,8 +15,6 @@ module HA.RecoveryCoordinator.Castor.Drive.Events
   , ExpanderReset(..)
   , ResetAttempt(..)
   , ResetAttemptResult(..)
-  , ResetSuccess(..)
-  , ResetFailure(..)
     -- * Metadata drive events
   , RaidUpdate(..)
     -- * SMART test EventsΩ
@@ -42,22 +40,9 @@ data ResetAttempt = ResetAttempt StorageDevice
 
 instance Binary ResetAttempt
 
--- | Event sent when a ResetAttempt were successful.
-newtype ResetSuccess =
-    ResetSuccess StorageDevice
-    deriving (Eq, Show, Binary)
-
--- | Event sent when a ResetAttempt failed.
-newtype ResetFailure =
-    ResetFailure StorageDevice
-    deriving (Eq, Show, Binary)
-
 -- | Result for 'ResetAttempt'
---
--- TODO: Consider merging 'ResetFailure' and 'ResetSuccess' and
--- migrating the rules. Or renaming this.
-data ResetAttemptResult = ResetAttemptFailure ResetFailure
-                        | ResetAttemptSuccess ResetSuccess
+data ResetAttemptResult = ResetFailure StorageDevice
+                        | ResetSuccess StorageDevice
   deriving (Eq, Show, Typeable, Generic)
 
 instance Binary ResetAttemptResult

--- a/mero-halon/src/lib/HA/Services/SSPL/CEP.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/CEP.hs
@@ -572,24 +572,22 @@ ruleMonitorRaidData = define "monitor-raid-data" $ do
 
   setPhaseIf reset_success
     -- TODO: relies on drive reset rule; TODO: nicer local state
-    ( \(HAEvent eid (ResetSuccess x) _) _ l -> case l of
-        Just (_,_,y,_,_) | x == y -> return $ Just eid
+    ( \msg _ l -> case (msg, l) of
+        (ResetSuccess x, Just (_,_,y,_,_)) | x == y -> return $ Just ()
         _ -> return Nothing
-    ) $ \eid -> do
+    ) $ \() -> do
       Just (nid, _, _, device, path) <- get Local
       -- Add drive back into array
       void $ sendNodeCmd nid Nothing (NodeRaidCmd device (RaidAdd path))
-      messageProcessed eid
       -- At this point we are done
       continue end
 
   setPhaseIf reset_failure
-    ( \(HAEvent eid (ResetFailure x) _) _ l -> case l of
-        Just (_,_,y,_,_) | x == y -> return $ Just eid
+    ( \msg _ l -> case (msg, l) of
+        (ResetFailure x, Just (_,_,y,_,_)) | x == y -> return $ Just ()
         _ -> return Nothing
-    ) $ \eid -> do
+    ) $ \() -> do
       -- TODO: log an IEM (SEM?) here that things are wrong
-      messageProcessed eid
       continue end
 
   directly end stop

--- a/mero-halon/tests/HA/Castor/Story/Tests.hs
+++ b/mero-halon/tests/HA/Castor/Story/Tests.hs
@@ -763,7 +763,6 @@ testMetadataDriveFailed transport pg = run transport pg interceptor [] test wher
       usend rmq . MQSubscribe "sspl_iem" =<< getSelfPid
 
       subscribe rc (Proxy :: Proxy (HAEvent (NodeId, SensorResponseMessageSensor_response_typeRaid_data)))
-      subscribe rc (Proxy :: Proxy (HAEvent ResetFailure))
 
       usend rmq $ MQPublish "sspl_halon" "sspl_ll" message
       nid <- getSelfNode


### PR DESCRIPTION
*Created by: Fuuzetsu*

There were multiple cases when `SDOngoingReset` would remain attached to
`StorageDevice` in RG even though the reset rule terminated already. We
now make sure to go through a `finalizer` phase which unsets the
attribute if present (and does nothing if not).

We go through finalizer in the starting body of the rule even though we
may not have set it in that run to account for RC restart:

* reset starts
* drive marked
* RC restarts
* rule starts
* drive may no longer be eligible for reset
* rule ends but marker is still around

Further, on drive attach failure, we actually fail the drive and notify
DM instead of simply doing nothing.

Lastly, remove `ResetSuccess` and `ResetFailure` types and make users
watch for `ResetAttemptResult` instead emitted by the job.