### PR TITLE
[HALON-373] Implement ruleProcessStart

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Castor/Process.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Castor/Process.hs
@@ -4,30 +4,22 @@
 -- Copyright : (C) 2016 Seagate Technology Limited.
 -- License   : All rights reserved.
 module HA.RecoveryCoordinator.Events.Castor.Process
-  ( ProcessRecoveryResult(..)
-  , ProcessRestartRequest(..)
+  ( ProcessStartRequest(..)
+  , ProcessStartResult(..)
   ) where
 
 import           Data.Binary
-import           Data.Hashable
 import           Data.Typeable
 import           GHC.Generics
 import qualified HA.Resources.Mero as M0
-import           Mero.ConfC (Fid)
 
--- | Event is arrived in case if recovery failed, this event goes
--- via replicated state.
-data ProcessRecoveryResult
-  = ProcessRecoveryFailure (Fid, String)
-    -- ^ When process recovery fails
-  | ProcessRecoveryNotNeeded Fid
-    -- ^ When there is no need to recover the process,
-    -- due to e.g. cluster state being invalid.
-  deriving (Show, Eq, Ord, Generic, Typeable)
-
-instance Binary ProcessRecoveryResult
-instance Hashable ProcessRecoveryResult
-
-newtype ProcessRestartRequest = ProcessRestartRequest M0.Process
+-- | Request that process be started.
+newtype ProcessStartRequest = ProcessStartRequest M0.Process
   deriving (Show, Eq, Ord, Typeable, Generic)
-instance Binary ProcessRestartRequest
+instance Binary ProcessStartRequest
+
+-- | Reply in job handling 'ProcessStartRequest'
+data ProcessStartResult = ProcessStarted M0.Process
+                        | ProcessStartFailed M0.Process String
+  deriving (Show, Eq, Ord, Typeable, Generic)
+instance Binary ProcessStartResult

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Mero.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Mero.hs
@@ -15,8 +15,6 @@ module HA.RecoveryCoordinator.Events.Mero
      -- ** Mero kernel.
    , MeroKernelFailed(..)
    , NodeKernelFailed(..)
-     -- ** Process.
-   , ProcessConfigured(..)
    -- * Requests
    , GetSpielAddress(..)
    -- * Jobs
@@ -42,7 +40,6 @@ import HA.Resources
 import HA.Resources.Castor
 import HA.Resources.Mero.Note
 import qualified HA.Resources.Mero as M0
-import qualified Mero.ConfC as M0 (Fid)
 
 import Control.Applicative (many)
 import Control.Distributed.Process (ProcessId, RemoteTable, Static, SendPort)
@@ -91,16 +88,6 @@ instance Binary NewMeroClientProcessed
 data GetSpielAddress = GetSpielAddress ProcessId
        deriving (Eq, Show, Typeable, Generic)
 instance Binary GetSpielAddress
-
--- | Event is emitted when some process have been configured
--- configured, i.e. created config file and mkfs done (if needed).
---
--- This may be either succesfull or not.
-data ProcessConfigured
-       = ProcessConfigured M0.Fid
-       | ProcessConfigureFailed M0.Fid
-       deriving (Eq, Show, Typeable, Generic)
-instance Binary ProcessConfigured
 
 -- | Universally quantified state 'set' request.
 --   Typically, one creates a state 'set' request, then

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Job/Actions.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Job/Actions.hs
@@ -96,7 +96,7 @@ mkJobRule (Job name)
                     insertWithStorageMapRC (mappend) input (JobDescription [eid] listeners)
           else do
               phaseLog "request" $ show input
-              modify Local $ rlens fldRequest .~ (Field $ Just input)
+              modify Local $ rlens fldRequest . rfield .~ Just input
               check_input input >>= \case
                 Nothing -> do
                   phaseLog "action" "Ignoring message due to rule filter."

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Mero/Conf.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Mero/Conf.hs
@@ -347,12 +347,12 @@ mkPhaseNotify :: (Eq (M0.StateCarrier b), M0.HasConfObjectState b, Typeable (M0.
               -> RuleM LoopState l (b -> M0.StateCarrier b -> PhaseM LoopState l [Jump PhaseHandle])
 mkPhaseNotify t getter onFailure onSuccess = do
   notify_done <- phaseHandle "Notification done"
-  notify_failed <- phaseHandle "Notification timed out"
+  notify_timed_out <- phaseHandle "Notification timed out"
 
   let getterP l = fmap (fmap (==)) (getter l)
 
   setPhaseNotified notify_done getterP $ \(o, oSt) -> onSuccess o oSt >>= switch
-  directly notify_failed onFailure
+  directly notify_timed_out onFailure
 
   return $ \obj objSt -> do
     rg <- getLocalGraph
@@ -362,7 +362,7 @@ mkPhaseNotify t getter onFailure onSuccess = do
       onSuccess obj objSt
     else do
       applyStateChanges [stateSet obj objSt]
-      return [notify_done, timeout t notify_failed]
+      return [notify_done, timeout t notify_timed_out]
 
 -- | Rule for cascading state changes
 data StateCascadeRule a b where

--- a/mero-halon/src/lib/HA/Resources/Castor.hs
+++ b/mero-halon/src/lib/HA/Resources/Castor.hs
@@ -185,10 +185,35 @@ data HalonVars = HalonVars
   -- ^ How often should the keepalive check trigger in the mero
   -- process keepalive rule. Seconds.
   , _hv_keepalive_timeout :: Int
-  -- ^ How long to allow for a process to go on without a keepalive
-  -- reply coming back. Seconds.
+  -- ^ How many seconds to allow for a process to go on without a keepalive
+  -- reply coming back.
   , _hv_drive_reset_max_retries :: Int
   -- ^ How many times we want to retry disk reset procedure before giving up.
+  , _hv_process_configure_timeout :: Int
+  -- ^ How many seconds until process configuration is considered to
+  -- be timed out. This includes time spent waiting on @mero-mkfs@.
+  , _hv_process_start_cmd_timeout :: Int
+  -- ^ How many seconds to wait for a process start command to return.
+  -- Note that this is not the same as the time we should wait for a
+  -- process to successfully start, for that see
+  -- '_hv_process_start_timeout'. For configuration timeout
+  -- (@mero-mkfs@ &c.) see '_hv_process_configure_timeout'.
+  , _hv_process_start_timeout :: Int
+  -- ^ How many seconds to wait for the process to start after the
+  -- process start command has completed. For the timeout pertaining
+  -- to the timeout of the start command itself, see
+  -- '_hv_process_start_cmd_timeout'.
+  , _hv_process_max_start_attempts :: Int
+  -- ^ How many times to try and start the same process if it fails to
+  -- start. Note that if systemctl exits with an unexpected error
+  -- code, process start is failed straight away.
+  , _hv_process_restart_retry_interval :: Int
+  -- ^ How many seconds to wait before we try to start a process again
+  -- in case it has failed to start and we haven't met
+  -- '_hv_process_max_start_attempts'.
+  , _hv_mero_kernel_start_timeout :: Int
+  -- ^ How many seconds to wait for halon:m0d (and @mero-kernel@) to
+  -- come up and declare channels.
   } deriving (Show, Eq, Ord, Typeable, Generic)
 
 instance Binary HalonVars

--- a/mero-halon/src/lib/HA/Resources/HalonVars.hs
+++ b/mero-halon/src/lib/HA/Resources/HalonVars.hs
@@ -31,6 +31,12 @@ defaultHalonVars = HalonVars
   , _hv_keepalive_frequency = 30
   , _hv_keepalive_timeout = 115
   , _hv_drive_reset_max_retries = 3
+  , _hv_process_configure_timeout = 300
+  , _hv_process_start_cmd_timeout = 300
+  , _hv_process_start_timeout = 180
+  , _hv_process_max_start_attempts = 5
+  , _hv_process_restart_retry_interval = 5
+  , _hv_mero_kernel_start_timeout = 300
   }
 
 -- | Get 'HalonVars' from RG

--- a/mero-halon/src/lib/HA/Services/Mero/Types.hs
+++ b/mero-halon/src/lib/HA/Services/Mero/Types.hs
@@ -131,18 +131,19 @@ instance Hashable ProcessRunType
 --   A process may either fetch its configuration from local conf.xc file,
 --   or it may connect to a confd server.
 data ProcessConfig =
-    ProcessConfigLocal Fid String ByteString -- ^ Process fid, endpoint, conf.xc
-  | ProcessConfigRemote Fid String -- ^ Process fid, endpoint
+    ProcessConfigLocal M0.Process ByteString
+    -- ^ Process fid, endpoint, conf.xc
+  | ProcessConfigRemote M0.Process
+  -- ^ Process fid, endpoint
   deriving (Eq, Show, Typeable, Generic)
 instance Binary ProcessConfig
 instance Hashable ProcessConfig
 
 -- | Control system level m0d processes.
 data ProcessControlMsg =
-    StartProcesses [(ProcessRunType, Fid)]
+    StartProcess ProcessRunType M0.Process
   | StopProcesses [(ProcessRunType, Fid)]
-  | RestartProcesses [(ProcessRunType, Fid)]
-  | ConfigureProcesses [(ProcessRunType, ProcessConfig, Bool)]
+  | ConfigureProcess ProcessRunType ProcessConfig Bool
   deriving (Eq, Show, Typeable, Generic)
 instance Binary ProcessControlMsg
 instance Hashable ProcessControlMsg
@@ -150,25 +151,19 @@ instance Hashable ProcessControlMsg
 -- | Result of a process control invocation. Either it succeeded, or
 --   it failed with a message.
 data ProcessControlResultMsg =
-    ProcessControlResultMsg NodeId [Either (Fid, Maybe Int) (Fid, String)]
+    ProcessControlResultMsg NodeId (Either (M0.Process, String) (M0.Process, Maybe Int))
   deriving (Eq, Generic, Show, Typeable)
 instance Binary ProcessControlResultMsg
 instance Hashable ProcessControlResultMsg
 
 data ProcessControlResultStopMsg =
-      ProcessControlResultStopMsg NodeId [Either Fid (Fid,String)]
+      ProcessControlResultStopMsg NodeId [Either (Fid,String) Fid]
   deriving (Eq, Generic, Show, Typeable)
 instance Binary ProcessControlResultStopMsg
 instance Hashable ProcessControlResultStopMsg
 
-data ProcessControlResultRestartMsg =
-    ProcessControlResultRestartMsg NodeId [Either (Fid, Maybe Int) (Fid,String)]
-  deriving (Eq, Generic, Show, Typeable)
-instance Binary ProcessControlResultRestartMsg
-instance Hashable ProcessControlResultRestartMsg
-
 data ProcessControlResultConfigureMsg =
-      ProcessControlResultConfigureMsg NodeId [Either Fid (Fid,String)]
+      ProcessControlResultConfigureMsg NodeId (Either (M0.Process, String) M0.Process)
   deriving (Eq, Generic, Show, Typeable)
 instance Binary ProcessControlResultConfigureMsg
 instance Hashable ProcessControlResultConfigureMsg


### PR DESCRIPTION
*Created by: Fuuzetsu*

This rule supersedes restart rule functionality as well as the use of
various helpers which were scattered around the code seemingly randomly.
Now the user only needs to fire-and-forget: dealing with process
configuration, starting, notifications &c. is all performed by the job.

It is still up to the user to ensure the environment is set up properly
however: the rule checks if everything seems OK but will happily return
process start failure if it is not the case. In fact, it will even fail
an already running process if we request start for it but the
environment isn't correct.

Restart process control messages were squashed into start messages which
were unused (due to a bug). Further, start/configure process control
messages are now made to only work over 1 process at a time: this
greatly simplifies logic, removes need for dispatch rules and removes
need for covoluted helpers that built start/configure messages. The
drawback is that we send more messages on the wire: we do not send so
many process messages where this should ever be a problem. We no longer
send fids and endpoints explicitly but instead send proper `Process`
objects. This allows us to retrieve endpoint on halon:m0d side, have
nicer logging, perform nicer comparisons &c. Lastly, results produced by
start/stop/configure control messages inside Either were flipped:
indicate failure in Left and success in Right. This is now consistent
with rest of the system and we don't have awkward side-switching.

HalonVars was extended with multiple new values. This removes any
hard-coded times that were in the code modified in this commit. As it
seems this will be the way to define options at least for short-term and
in light of recent discussion to make these configurable on running
systems through hctl, it makes sense to do so. Also allows us to write
saner tests if we choose to do so.

Any users of the process control channels were modified. Process start
now only happens in 4 places (as far as I could find):

* Bootstrap, boot level 0
* Bootstrap, boot level 1
* Bootstrap, clients
* Process failure -> process start

All of these simply dispatch ruleProcessStart and await results. Due to
HalonVars changes and moving configuration into ruleProcessStart, the
bootstrap procedures do not have timeouts themselves. Previously it
could take a very long time for bootstrap timeout to occur: `mkLoop`
helpers used meant that as long as a message came through sometimes,
many processes could hang for a very long time until failure. Now each
process is responsible for itself and managing its own timeout. This
means that if a process fails or times out, bootstrap procedure will
know sooner and can fail much sooner. This stops scenarios where we had
a 10 minute cluster timeout but it took 30 minutes to actually time out:
whenever a process would reply with result, the timeout refreshed.

We no longer manually set `PSStarting` on service/process in graph.
ruleProcessRestart does a proper notification for process (and for
services through cascading). Mero seems fine with this so this hack is
no longer necessary. We still do this in stop case which was largely
untouched and out of scope of HALON-373.

Tested on devvm and dev1-1. Worked in presence of failure on
dev1-1 (i.e. properly failed bootstrap) due to minor caveat (HALON-537).
Worked through `start -> stop -> start`. `mero-halon:scheduler-tests`
pass. `mero-halon:tests` pass except for expander reset (unrelated to
PR).