### PR TITLE
HALON-529: Output meaningful information about SNS in cluster status

### DIFF
--- a/mero-halon/src/halonctl/Handler/Cluster.hs
+++ b/mero-halon/src/halonctl/Handler/Cluster.hs
@@ -594,11 +594,14 @@ prettyReport showDevices (ReportClusterState status sns info' mstats hosts) = do
         putStrLn $ "      Total segments: " ++ show (_fss_total_seg . M0._fs_stats $ stats)
         putStrLn $ "      Free segments: " ++ show (_fss_free_seg . M0._fs_stats $ stats)
       unless (null sns) $ do
-         putStrLn $ "    sns repairs:"
+         putStrLn $ "    sns operations:"
          forM_ sns $ \(M0.Pool pool_fid, s) -> do
-           putStrLn $ "      " ++ fidToStr pool_fid ++ ":"
-           forM_ (M0.priStateUpdates s) $ \(M0.SDev{d_fid=sdev_fid,d_path=sdev_path},_) -> do
-             putStrLn $ "        " ++ fidToStr sdev_fid ++ " -> " ++ sdev_path
+           putStrLn $ "      pool:" ++ fidToStr pool_fid ++ " => " ++ show (M0.prsType s)
+           putStrLn $ "      uuid:" ++ show (M0.prsRepairUUID s)
+           forM_ (M0.prsPri s) $ \i -> do
+             putStrLn $ "      time of start: " ++ show (M0.priTimeOfFirstCompletion i) --XXX: bad naming?
+             forM_ (M0.priStateUpdates i) $ \(M0.SDev{d_fid=sdev_fid,d_path=sdev_path},_) -> do
+               putStrLn $ "          " ++ fidToStr sdev_fid ++ " -> " ++ sdev_path
       putStrLn $ "Hosts:"
       forM_ hosts $ \(Castor.Host qfdn, ReportClusterHost m0fid st ps sdevs) -> do
          putStrLn $ "  " ++ qfdn ++ showNodeFid m0fid ++ " ["++ M0.prettyNodeState st ++ "]"

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Castor/Cluster.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Events/Castor/Cluster.hs
@@ -124,7 +124,7 @@ newtype ClusterResetRequest = ClusterResetRequest Bool
 
 data ReportClusterState = ReportClusterState
       { csrStatus     :: Maybe M0.MeroClusterState
-      , csrSNS        :: [(M0.Pool, M0.PoolRepairInformation)]
+      , csrSNS        :: [(M0.Pool, M0.PoolRepairStatus)]
       , csrInfo       :: Maybe (M0.Profile, M0.Filesystem)
       , csrStats      :: Maybe M0.FilesystemStats
       , csrHosts      :: [(Castor.Host, ReportClusterHost)]

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Cluster.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Cluster.hs
@@ -193,7 +193,7 @@ requestClusterStatus = defineSimple "castor::cluster::request::status"
       rg <- getLocalGraph
       profile <- getProfile
       filesystem <- getFilesystem
-      repairs <- fmap catMaybes $ traverse (\p -> fmap (p,) <$> getPoolRepairInformation p) =<< getPool
+      repairs <- fmap catMaybes $ traverse (\p -> fmap (p,) <$> getPoolRepairStatus p) =<< getPool
       let status = getClusterStatus rg
           stats = filesystem >>= \fs -> G.connectedTo fs R.Has rg
       hosts <- forM (G.connectedTo R.Cluster R.Has rg) $ \host -> do


### PR DESCRIPTION
*Created by: qnikst*

Output PoolRepairStatus information in cluster status output.
Added type of repair and it's UUID.