### PR TITLE
[HALON-556] Don't trigger spurious process restart

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Process.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Process.hs
@@ -72,6 +72,11 @@ ruleProcessDispatchRestart = define "rule-process-dispatch-restart" $ do
 
   startFork rule_init ()
   where
+    -- Don't restart after we leave inhibited, for example after node
+    -- recovery: other mechanisms should recover the processes
+    -- explicitly
+    isProcFailed (M0.PSInhibited _) (M0.PSFailed _) = False
+    -- Don't restart if we change reason for failure
     isProcFailed (M0.PSFailed _) (M0.PSFailed _) = False
     isProcFailed _ (M0.PSFailed _) = True
     isProcFailed _ _ = False


### PR DESCRIPTION
*Created by: Fuuzetsu*

Due to cascading, when we transition node to online from a failed state,
we uninhibit processes. This usually leads processes (including halon
process) to be moved into PSFailed which caused a (re)start request
which subsequently failed for halon process (by design).