### PR TITLE
[HALON-537] Act on exceptions from m0_init

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Node.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Node.hs
@@ -253,7 +253,7 @@ eventKernelStarted = defineSimpleTask "castor::node::event::kernel-started" $ \(
 -- Emits:        'NodeKernelFailed'
 -- State-Changes: 'M0.Node' Failed
 eventKernelFailed :: Definitions LoopState ()
-eventKernelFailed = defineSimpleTask "castor::node::event::kernel-failed" $ \(MeroKernelFailed pid _) -> do
+eventKernelFailed = defineSimpleTask "castor::node::event::kernel-failed" $ \(MeroKernelFailed pid msg) -> do
   g <- getLocalGraph
   let node = R.Node $ processNodeId pid
       m0nodes = nodeToM0Node node g
@@ -264,7 +264,8 @@ eventKernelFailed = defineSimpleTask "castor::node::event::kernel-failed" $ \(Me
         , any (\s -> M0.s_type s == CST_HA)
            $ G.connectedTo p M0.IsParentOf g
         ]
-  applyStateChanges $ (`stateSet` M0.PSFailed "mero-kernel failed to start") <$> haprocesses
+  let failMsg = "mero-kernel failed to start: " ++ msg
+  applyStateChanges $ (`stateSet` M0.PSFailed failMsg) <$> haprocesses
   promulgateRC $ encodeP $ ServiceStopRequest node m0d
   for_ m0nodes $ notify . KernelStartFailure
 

--- a/rpclite/Mero.hsc
+++ b/rpclite/Mero.hsc
@@ -10,12 +10,9 @@
 {-# LANGUAGE DeriveDataTypeable        #-}
 {-# LANGUAGE LambdaCase                #-}
 module Mero
-  ( m0_init
-  , m0_fini
-  , withM0
+  ( withM0
   , sendM0Task
   , sendM0Task_
-  , M0InitException(..)
   , M0WorkerIsNotStarted(..)
   , addM0Finalizer
   ) where
@@ -76,11 +73,7 @@ withM0 = bracket_ m0_init m0_fini . bracket runworker stopworker . const
       writeChan globalM0Chan Nothing
       joinM0OS mid
 
-newtype M0InitException = M0InitException CInt deriving (Show, Typeable)
-
-instance Exception M0InitException
-
--- | Exception means that 'withM0' or 'withM0Deferred' were not called, so
+-- | Exception means that 'withM0' or was not called, so
 -- there is no worker that could start mero or process query.
 data M0WorkerIsNotStarted = M0WorkerIsNotStarted deriving (Show, Typeable)
 
@@ -109,8 +102,9 @@ replaceGlobalWorker tid = do
 
 data Task = forall a . Task (IO (Either SomeException a)) (MVar (Either SomeException a))
 
--- | Send task to M0 worker, may throw 'M0InitException' if mero worker
--- failed to initialize mero. This call blocks until the task is completed.
+-- | Send task to M0 worker, may throw an exception if mero worker
+-- failed to initialize mero. This call blocks until the task is
+-- completed.
 sendM0Task :: IO a -> IO a
 sendM0Task f = do
     box <- newEmptyMVar


### PR DESCRIPTION
*Created by: Fuuzetsu*

We can now actually fail halon:m0d in presence of exceptions (IOErrors
at least) in timely manner and with a message. This means we'll no
longer have to wait for full kernel start timeout during bootstrap and
whatnot to find out something went wrong.