### PR TITLE
[HALON-555] Fix hctl cluster start hanging forever

### DIFF
--- a/mero-halon/src/halonctl/Handler/Cluster.hs
+++ b/mero-halon/src/halonctl/Handler/Cluster.hs
@@ -442,7 +442,6 @@ clusterStartCommand :: [NodeId]
                     -> Bool
                     -> Process ()
 clusterStartCommand eqnids False = do
-  -- FIXME implement async also
   subscribeOnTo eqnids (Proxy :: Proxy ClusterStartResult)
   _ <- promulgateEQ eqnids ClusterStartRequest
   Published msg _ <- expect :: Process (Published ClusterStartResult)
@@ -453,9 +452,7 @@ clusterStartCommand eqnids False = do
       ClusterStartOk        -> exitSuccess
       ClusterStartTimeout{} -> exitFailure
       ClusterStartFailure{} -> exitFailure
-
 clusterStartCommand eqnids True = do
-  -- FIXME implement async also
   _ <- promulgateEQ eqnids ClusterStartRequest
   liftIO $ putStrLn "Cluster start request sent."
 

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Process.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Process.hs
@@ -105,6 +105,9 @@ jobProcessStart = Job "process-start"
 -- * Is halon:m0d up and running on the node?
 -- * What is the result of the job?
 --
+-- This job always returns: it's not necessary for the caller to have
+-- a timeout.
+--
 -- TODO: We need better invariant checking: for example we want to
 -- verify process doesn't enter unexpected state, that node remains
 -- online, that cluster remains online. Basically we have little

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Mero/Conf.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Mero/Conf.hs
@@ -51,6 +51,7 @@ import Control.Monad.Fix (fix)
 import Control.Lens
 
 import Data.Constraint (Dict)
+import Data.Foldable (for_)
 import Data.Maybe (catMaybes, listToMaybe, mapMaybe, maybeToList)
 import Data.Monoid
 import Data.Traversable (mapAccumL)
@@ -187,7 +188,7 @@ genericApplyDeferredStateChanges (DeferredStateChanges f s i) action = do
   diff <- mkStateDiff f (encodeP i) []
   notifyMeroAsync diff s
   let (InternalObjectStateChange iosc) = i
-  forM_ iosc $ \(AnyStateChange a o n _) -> do
+  for_ iosc $ \(AnyStateChange a o n _) -> do
     phaseLog "state-update" $ unwords
       [ M0.showFid a
       , "transitioned to"

--- a/mero-halon/src/lib/HA/Resources/Castor.hs
+++ b/mero-halon/src/lib/HA/Resources/Castor.hs
@@ -214,6 +214,9 @@ data HalonVars = HalonVars
   , _hv_mero_kernel_start_timeout :: Int
   -- ^ How many seconds to wait for halon:m0d (and @mero-kernel@) to
   -- come up and declare channels.
+  , _hv_clients_start_timeout :: Int
+  -- ^ How many seconds to wait for clients during cluster bootstrap
+  -- before giving up on receiving a result.
   } deriving (Show, Eq, Ord, Typeable, Generic)
 
 instance Binary HalonVars

--- a/mero-halon/src/lib/HA/Resources/HalonVars.hs
+++ b/mero-halon/src/lib/HA/Resources/HalonVars.hs
@@ -37,6 +37,7 @@ defaultHalonVars = HalonVars
   , _hv_process_max_start_attempts = 5
   , _hv_process_restart_retry_interval = 5
   , _hv_mero_kernel_start_timeout = 300
+  , _hv_clients_start_timeout = 600
   }
 
 -- | Get 'HalonVars' from RG

--- a/mero-halon/src/lib/HA/Resources/Mero.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero.hs
@@ -522,6 +522,8 @@ deriveSafeCopy 0 'base ''DiskV
 -- instances.
 --
 -- Normally you should use 'mkTimeSpec' to create these.
+--
+-- TODO: Move this somewhere else
 newtype TimeSpec = TimeSpec { _unTimeSpec :: C.TimeSpec }
   deriving (Eq, Num, Ord, Read, Show, Generic, Typeable)
 
@@ -565,6 +567,12 @@ instance Binary TimeSpec where
 -- | Get current time using a 'C.Monotonic' 'C.Clock'.
 getTime :: IO TimeSpec
 getTime = TimeSpec <$> C.getTime C.Monotonic
+
+-- | Get number of seconds that have elapsed since the given 'TimeSpec'.
+secondsSince :: TimeSpec -> IO Int
+secondsSince oldSpec = do
+  ct <- getTime
+  return . timeSpecToSeconds $ ct - oldSpec
 
 -- | Classifies 'PoolRepairInformation'. By the time we get
 -- information back from mero about the status of the pool, we no


### PR DESCRIPTION
*Created by: Fuuzetsu*

The main issue was that the start node processes jobs didn't always
return. Simply make it always return. Update bootstrap rule to wait for
the appropriate job results (through listeners): this lets us avoid
weird situations where node join (such as after reboot or initial data
load) is ran concurrently with bootstrap.

Took liberty to improve clients bootstrap phase a little: wait for all
messages on a single timeout as opposed to 10 minutes between each
message. Also wait for the right jobs just in case.