### PR TITLE
Don't exit in clusterCommand on success

### DIFF
--- a/mero-halon/src/halonctl/Handler/Cluster.hs
+++ b/mero-halon/src/halonctl/Handler/Cluster.hs
@@ -544,7 +544,7 @@ clusterCommand eqnids mk output = do
     Nothing -> do
       hPutStrLn stderr "Timed out waiting for cluster status reply from RC."
       exitFailure
-    Just () -> exitSuccess
+    Just () -> return ()
   where
     wait = void (expect :: Process ProcessMonitorNotification)
 


### PR DESCRIPTION
*Created by: Fuuzetsu*

Callers may be listening for things after it exits, such as sync cluster
stop &c.