### PR TITLE
[HALON-514] Add timeout opt to hctl cluster status

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Cluster.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Rules/Castor/Cluster.hs
@@ -181,7 +181,7 @@ eventUpdatePrincipalRM = defineSimpleTask "castor::cluster::event::update-princi
 -------------------------------------------------------------------------------
 -- Requests handling
 -------------------------------------------------------------------------------
--- $requests.
+-- $requests
 -- User can control whole cluster state using following requests.
 -- Each request trigger a long procedure of moving cluster into desired state
 -- if those transition is possible.
@@ -190,8 +190,8 @@ eventUpdatePrincipalRM = defineSimpleTask "castor::cluster::event::update-princi
 --
 -- Nilpotent request.
 requestClusterStatus :: Definitions LoopState ()
-requestClusterStatus = defineSimple "castor::cluster::request::status"
-  $ \(HAEvent eid  (ClusterStatusRequest ch) _) -> do
+requestClusterStatus = defineSimpleTask "castor::cluster::request::status"
+  $ \(ClusterStatusRequest ch) -> do
       rg <- getLocalGraph
       profile <- getProfile
       filesystem <- getFilesystem
@@ -224,7 +224,6 @@ requestClusterStatus = defineSimple "castor::cluster::request::status"
         , csrStats  = stats
         , csrHosts  = hosts
         }
-      messageProcessed eid
 
 jobClusterStart :: Job ClusterStartRequest ClusterStartResult
 jobClusterStart = Job "castor::cluster::start"


### PR DESCRIPTION
*Created by: Fuuzetsu*

Originally the ticket was about finding out "root cause" of hctl cluster
status not returning. But the ticket makes it clear that it happens
under load. But:

* We already print a message and exit with failure (done recently in
  other issue)

* The code itself is straight forward, single phase: there is not much
  that can be blame on here for failing under load. It was just too
  slow. Custom timeout can just let the user wait for longer.

* Halon itself is now much less resource hungry than it was when the
  issue was created, meaning the situation should be better much more
  often than it was.

Performance improvement and custom timeout should be enough to assure we
get cluster status eventually. If we can't perform a single message
round-trip, we have bigger problems.