### PR TITLE
[HALON-490] Fail early if initial data problems

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Node/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Node/Rules.hs
@@ -398,7 +398,7 @@ ruleNodeNew = mkJobRule processNodeNew args $ \finish -> do
     createMeroClientConfig fs host hhi
     continue confd_running
 
-  setPhase wait_data_load $ \Event.InitialDataLoaded -> do
+  setPhaseIf wait_data_load initialDataLoaded $ \() -> do
     Just (StartProcessNodeNew node) <- getField . rget fldReq <$> get Local
     route node >>= switch
 
@@ -429,6 +429,10 @@ ruleNodeNew = mkJobRule processNodeNew args $ \finish -> do
 
   return check
   where
+    initialDataLoaded :: Event.InitialDataLoaded -> g -> l -> Process (Maybe ())
+    initialDataLoaded Event.InitialDataLoaded _ _ = return $ Just ()
+    initialDataLoaded Event.InitialDataLoadFailed{} _ _ = return Nothing
+
     fldReq :: Proxy '("request", Maybe StartProcessNodeNew)
     fldReq = Proxy
     fldRep :: Proxy '("reply", Maybe NewMeroServer)

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Events/Cluster.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Events/Cluster.hs
@@ -25,8 +25,9 @@ import GHC.Generics
 newtype NewNodeConnected = NewNodeConnected Node
    deriving (Eq, Show, Typeable, Generic, Binary)
 
--- | Initial data were loaded.
+-- | Initial data was loaded or has failed to load.
 data InitialDataLoaded = InitialDataLoaded
+                       | InitialDataLoadFailed String
    deriving (Eq, Show, Typeable, Generic)
 
 instance Binary InitialDataLoaded

--- a/mero-halon/tests/HA/Test/Disconnect.hs
+++ b/mero-halon/tests/HA/Test/Disconnect.hs
@@ -243,7 +243,7 @@ testRejoinTimeout baseTransport connectionBreak = withTmpDirectory $ do
 
 #ifdef USE_MERO
       _ <- promulgateEQ [localNodeId m1] defaultInitialData
-      _ <- expectPublished (Proxy :: Proxy InitialDataLoaded)
+      InitialDataLoaded <- expectPublished Proxy
 #endif
 
       say $ "isolating TS node " ++ show (localNodeId <$> [m1])
@@ -305,7 +305,7 @@ testRejoinRCDeath baseTransport connectionBreak = withTmpDirectory $ do
 
 #ifdef USE_MERO
       _ <- promulgateEQ [localNodeId m1] defaultInitialData
-      _ <- expectPublished (Proxy :: Proxy InitialDataLoaded)
+      InitialDataLoaded <- expectPublished Proxy
 #endif
 
       say $ "isolating TS node " ++ show (localNodeId <$> [m1])
@@ -370,7 +370,7 @@ testRejoin baseTransport connectionBreak = withTmpDirectory $ do
       _ <- expectPublished (Proxy :: Proxy NewNodeConnected)
 #ifdef USE_MERO
       _ <- promulgateEQ [localNodeId m1] defaultInitialData
-      _ <- expectPublished (Proxy :: Proxy InitialDataLoaded)
+      InitialDataLoaded <- expectPublished Proxy
 #endif
 
       say $ "isolating TS node " ++ show (localNodeId <$> [m1])


### PR DESCRIPTION
*Created by: Fuuzetsu*

We now always validate initial data after it's loaded (and restore old
graph if valdiation fails).

Tests checking the validation function binding itself are now enabled.