### PR TITLE
[HALON-354] Fix tests and scheduler-tests

### DIFF
--- a/mero-halon/benchmarks/initial-data-gc.hs
+++ b/mero-halon/benchmarks/initial-data-gc.hs
@@ -17,7 +17,7 @@ import Control.Exception as E
 import Criterion.Main
 import HA.Castor.Tests (loadInitialData)
 import HA.ResourceGraph (Graph, getGraphResources, garbageCollectRoot)
-import Helper.Environment (systemHostname)
+import Network.BSD (getHostname)
 import Mero (withM0)
 import Network.Transport (Transport(..))
 import Network.Transport.InMemory (createTransport)
@@ -39,4 +39,4 @@ main = defaultMain [
 -- | Run 'loadInitialData' and retrieve the resulting graph.
 loadInitialDataGraph :: IO Graph
 loadInitialDataGraph = E.bracket createTransport closeTransport $ \t ->
-  withTmpDirectory $ withM0 $ loadInitialData systemHostname t
+  withTmpDirectory $ withM0 $ loadInitialData getHostname t

--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -436,6 +436,7 @@ Test-Suite testsnapshot2
                    network-transport-tcp,
                    distributed-commands,
                    process
+
   if !(flag(distributed-tests) && flag(long-tests))
     Buildable:     False
 
@@ -567,7 +568,9 @@ Test-Suite tests
                     process,
                     uuid,
                     exceptions,
-                    lens
+                    lens,
+                    split,
+                    aeson
   if flag(rpc)
       Build-Depends: network-transport-rpc
       CPP-Options:    -DUSE_RPC
@@ -640,7 +643,8 @@ Test-Suite scheduler-tests
                     process,
                     uuid,
                     exceptions,
-                    stm
+                    stm,
+                    split
 
   if flag(mero)
     CPP-Options:    -DUSE_MERO
@@ -746,7 +750,8 @@ Test-Suite test-bootstrap
                     process,
                     process-extras,
                     template-haskell,
-                    unix
+                    unix,
+                    split
   else
     Buildable:        False
 

--- a/mero-halon/src/lib/HA/Services/SSPL.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL.hs
@@ -192,7 +192,7 @@ startActuators :: Network.AMQP.Channel
                -> Process DeclareChannels
 startActuators chan ac pid monitorChan = do
     iemChan <- spawnChannelLocal $ \ch -> link pid >> (iemProcess $ acIEM ac) ch
-    systemdChan <- spawnChannelLocal $ \ch -> link pid >> (commandProcess $ acSystemd ac) ch
+    systemdChan <- spawnChannelLocal $ \ch -> link pid >> commandProcess (acSystemd ac) ch
     _ <- spawnLocal $ link pid >> replyProcess (acCommandAck ac)
     mypid <- getSelfPid
     let decl = DeclareChannels mypid (ActuatorChannels iemChan systemdChan)

--- a/mero-halon/tests/HA/Castor/Story/ProcessRestart.hs
+++ b/mero-halon/tests/HA/Castor/Story/ProcessRestart.hs
@@ -41,7 +41,6 @@ import           Network.Transport
 import           SSPL.Bindings
 import           Test.Framework
 import           Test.Tasty.HUnit (assertEqual)
-import           TestRunner
 
 mkTests :: (Typeable g, RGroup g) => Proxy g -> IO (Transport -> [TestTree])
 mkTests pg = do
@@ -120,12 +119,9 @@ doRestart :: (Typeable g, RGroup g)
           -- ^ Main test block
           -> IO ()
 doRestart transport pg startingState runRestartTest =
-  H.run transport pg interceptor [rule] test where
-  interceptor _ _ = return ()
+  H.run transport pg [rule] test where
 
-  test (TestArgs _ _ rc) rmq recv _ = do
-    H.prepareSubscriptions rc rmq
-    H.loadInitialData
+  test _ _ recv _ = do
     self <- getSelfPid
     nid <- getSelfNode
     _ <- promulgateEQ [nid] $ RuleHook self

--- a/mero-halon/tests/HA/RecoveryCoordinator/Helpers.hs
+++ b/mero-halon/tests/HA/RecoveryCoordinator/Helpers.hs
@@ -1,31 +1,37 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- |
--- Copyright : (C) 2015 Xyratex Technology Limited.
+-- Module    : HA.RecoveryCoordinator.Helpers
+-- Copyright : (C) 2015-2016 Seagate Technology Limited.
 -- License   : All rights reserved.
 --
 -- Collection of helper functions used by the HA.RecoveryCoordinator
 -- family of tests.
+--
+-- TODO: Fold into other helpers and only have one module (or 2, for mero).
 module HA.RecoveryCoordinator.Helpers where
 
-import           Control.Distributed.Process
-import           Control.Distributed.Process.Serializable
-import           HA.EventQueue.Producer (promulgateEQ)
-import           HA.EventQueue.Types (HAEvent(..))
-import           HA.Service
-import           HA.RecoveryCoordinator.Service.Events
-import           HA.Resources
-import           HA.Encode
-import           Network.CEP (Published(..))
-import           Network.Transport (Transport(..))
-import           Data.Typeable
-import           Prelude hiding ((<$>), (<*>))
-import           RemoteTables ( remoteTable )
-import           TestRunner
+import Control.Distributed.Process
+import Control.Distributed.Process.Serializable
+import Data.Foldable (for_)
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8)
+import Data.Typeable
+import HA.Encode
+import HA.EventQueue.Producer (promulgateEQ)
+import HA.EventQueue.Types (HAEvent(..))
+import HA.RecoveryCoordinator.Service.Events
+import HA.Resources
+import HA.Service
+import HA.Services.SSPL.Rabbit
+import Network.CEP (Published(..))
+import Network.Transport (Transport(..))
+import RemoteTables ( remoteTable )
+import TestRunner
 
 -- | Run the test with some common test parameters
 runDefaultTest :: Transport -> Process () -> IO ()
-runDefaultTest transport act =   runTest 1 20 15000000 transport testRemoteTable $ \_ -> act
+runDefaultTest transport act = runTest 1 20 15000000 transport testRemoteTable $ \_ -> act
 
 testRemoteTable :: RemoteTable
 testRemoteTable = TestRunner.__remoteTableDecl $
@@ -33,9 +39,13 @@ testRemoteTable = TestRunner.__remoteTableDecl $
 
 -- | Awaits a message about the start of the given service. Waits
 -- until the right message is received.
+--
+-- Note that it will discard any 'ServiceStarted' messages that are
+-- also in the inbox before the message we're after even if their
+-- underlying service is not the correct one.
 serviceStarted :: Typeable a => Service a -> Process ProcessId
 serviceStarted srv = do
-  (Published (HAEvent _ (ServiceStarted _ msg pid)) _) <- expect
+  ServiceStarted _ msg pid <- eventPayload . pubValue <$> expect
   ServiceInfo srvi _ <- decodeP msg
   if maybe False (srv==) (cast srvi)
   then return pid
@@ -44,11 +54,13 @@ serviceStarted srv = do
 -- | Start the given 'Service' on the current node.
 serviceStart :: Configuration a => Service a -> a -> Process ()
 serviceStart svc conf = do
-    nid <- getSelfNode
-    let node = Node nid
-    _   <- promulgateEQ [nid] $ encodeP $ ServiceStartRequest Start node svc conf []
-    return ()
+  nid <- getSelfNode
+  let node = Node nid
+  _   <- promulgateEQ [nid] $ encodeP $ ServiceStartRequest Start node svc conf []
+  return ()
 
+-- | 'expect' a 'Published' message. It is up to the caller to have
+-- previously subscribed to the message.
 expectPublished :: Serializable a => Proxy a -> Process a
 expectPublished p = do
   say $ "Expecting " ++ show (typeRep p) ++ " to be published."
@@ -75,3 +87,19 @@ emptyMailbox t@(Proxy :: Proxy t) = expectTimeout 0 >>= \case
 -- | Prepend 'say' with @test =>@ for easy log search.
 sayTest :: String -> Process ()
 sayTest m = say $ "test => " ++ m
+
+-- | Purge any messages from the given rabbitmq queues. Useful to
+-- clear queues between tests. If you want to empty the queue from old
+-- messages, you probably want to call this before 'MQSubscribe' which
+-- will put the messages from the queue on a channel.
+purgeRmqQueues :: ProcessId -- ^ RMQ 'ProcessId'
+               -> [Text]  -- ^ Queues to purge
+               -> Process ()
+purgeRmqQueues rmq qs = do
+  self <- getSelfPid
+  for_ qs $ \q -> do
+    let msg = MQPurge (encodeUtf8 q) self
+    usend rmq msg
+    Just{} <- receiveTimeout (5 * 1000000)
+      [ matchIf (\m -> m == msg) (\_ -> return ()) ]
+    return ()

--- a/mero-halon/tests/HA/Test/Disconnect.hs
+++ b/mero-halon/tests/HA/Test/Disconnect.hs
@@ -242,7 +242,7 @@ testRejoinTimeout baseTransport connectionBreak = withTmpDirectory $ do
       _ <- expectPublished (Proxy :: Proxy NewNodeMsg)
 
 #ifdef USE_MERO
-      _ <- promulgateEQ [localNodeId m1] defaultInitialData
+      _ <- liftIO defaultInitialData >>= promulgateEQ [localNodeId m1]
       InitialDataLoaded <- expectPublished Proxy
 #endif
 
@@ -304,7 +304,7 @@ testRejoinRCDeath baseTransport connectionBreak = withTmpDirectory $ do
       _ <- expectPublished (Proxy :: Proxy NewNodeConnected)
 
 #ifdef USE_MERO
-      _ <- promulgateEQ [localNodeId m1] defaultInitialData
+      _ <- liftIO defaultInitialData >>= promulgateEQ [localNodeId m1]
       InitialDataLoaded <- expectPublished Proxy
 #endif
 
@@ -369,7 +369,7 @@ testRejoin baseTransport connectionBreak = withTmpDirectory $ do
 
       _ <- expectPublished (Proxy :: Proxy NewNodeConnected)
 #ifdef USE_MERO
-      _ <- promulgateEQ [localNodeId m1] defaultInitialData
+      _ <- liftIO defaultInitialData >>= promulgateEQ [localNodeId m1]
       InitialDataLoaded <- expectPublished Proxy
 #endif
 

--- a/mero-halon/tests/Helper/InitialData.hs
+++ b/mero-halon/tests/Helper/InitialData.hs
@@ -1,20 +1,54 @@
+{-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE RecordWildCards #-}
+-- |
+-- Module    : Helper.InitialData
+-- Copyright : (C) 2015-2016 Seagate Technology Limited.
+-- License   : All rights reserved.
+--
+-- Module containing configurable 'CI.InitialData' used throughout
+-- tests.
 module Helper.InitialData
   ( defaultGlobals
   , defaultInitialData
+  , defaultInitialDataSettings
   , initialData
+  , InitialDataSettings(..)
   ) where
 
-import Mero.ConfC (ServiceParams(..), ServiceType(..))
+import           Data.List.Split (splitOn)
+import           GHC.Word (Word8)
 import qualified HA.Resources.Castor.Initial as CI
+import           Helper.Environment (testListenName)
+import           Mero.ConfC (ServiceParams(..), ServiceType(..))
+import           Network.BSD (getHostName)
+import           Text.Printf
+import           Text.Read
 
-import System.IO.Unsafe
-import System.Environment (lookupEnv)
-import Data.Maybe (fromMaybe)
+-- | Configuration used in creation of 'CI.InitialData'. See 'initialData'.
+data InitialDataSettings = InitialDataSettings
+  { _id_hostname :: String
+    -- ^ Hostname of the node. Can usually be obtained with @hostname@
+    -- command. e.g. "devvm.seagate.com".
+  , _id_host_ip :: (Word8, Word8, Word8, Word8)
+  -- ^ IP of the main host: the host running the tests and RC.
+  -- e.g. "10.0.2.15" is provided as @(10,0,2,15)@.
+  , _id_servers :: Word8
+  -- ^ Number of servers (i.e. 'CI.Enclosure's and 'CI.M0Host's) to
+  -- generate. The naming scheme for enclosures in case @'_id_servers'
+  -- > 1@ is "enclosure_i" where @i@ is the last octet of the
+  -- enclosure's IP address. The IP address is constructed from
+  -- '_id_host_ip', increasing the last octet for each new enclosure,
+  -- allowing for overflow. Naming scheme for 'CI.M0Host's is
+  -- @'_id_hostname'_i@.
+  , _id_drives :: Int
+  -- ^ Number of drives __per enclosure__ to insert into the data.
+  , _id_globals :: CI.M0Globals
+  -- ^ Various global settings usually provided by the provisioner.
+  -- See 'defaultGlobals'.
+  } deriving (Show, Eq)
 
-import Helper.Environment
-
--- Defaults taken from http://es-gerrit.xyus.xyratex.com:8080/#/c/10913/1/modules/stx_halon/manifests/facts.pp
+-- | Defaults taken from
+-- <http://es-gerrit.xyus.xyratex.com:8080/#/c/10913/1/modules/stx_halon/manifests/facts.pp>
 defaultGlobals :: CI.M0Globals
 defaultGlobals = CI.M0Globals {
     CI.m0_data_units = 8
@@ -37,39 +71,37 @@ defaultGlobals = CI.M0Globals {
   , CI.m0_min_rpc_recvq_len = Nothing
 }
 
--- | Create initial data for use in tests.
-initialData :: String -- ^ Hostname prefix (or hostname if only one host)
-            -> String -- ^ Subnet (x.x.x)
-            -> Int -- ^ Number of servers
-            -> Int -- ^ Number of drives per server
-            -> CI.M0Globals -- ^ Mero globals
-            -> CI.InitialData
-initialData _ _ s ds (CI.M0Globals {..}) | (s*ds) < fromIntegral (d +2*p) =
-    error $ "initialData: the given number of devices ("
-          ++ show (s*ds)
-          ++ ") is smaller than 2 * parity_units + data_units (= "
-          ++ show (d + 2*p)
-          ++ ")."
-  where
-    d = m0_data_units
-    p = m0_parity_units
+-- | Helper for IP addresses formatted as a quadruple of 'Word8's.
+showIP :: (Word8, Word8, Word8, Word8) -> String
+showIP (x,y,z,w) = printf "%d.%d.%d.%d" x y z w
 
-initialData host_pfx ifaddr_pfx n_srv n_drv globs = CI.InitialData {
-    CI.id_m0_globals = globs
+initialData :: InitialDataSettings -> IO CI.InitialData
+initialData InitialDataSettings{..}
+  | (fromIntegral _id_servers * _id_drives) < fromIntegral (d + 2 * p) =
+     fail $ "initialData: the given number of devices ("
+         ++ show (fromIntegral _id_servers * _id_drives)
+         ++ ") is smaller than 2 * parity_units + data_units (= "
+         ++ show (d + 2 * p)
+         ++ ")."
+  where
+    d = CI.m0_data_units _id_globals
+    p = CI.m0_parity_units _id_globals
+initialData InitialDataSettings{..} = return $ CI.InitialData {
+    CI.id_m0_globals = _id_globals
   , CI.id_racks = [
       CI.Rack {
         CI.rack_idx = 1
       , CI.rack_enclosures = fmap
           (\i ->
-            let
-              host = case n_srv of
-                1 -> host_pfx
-                _ -> host_pfx ++ "_" ++ show i
-              ifaddr = ifaddr_pfx ++ "." ++ show i
+            let host = if _id_servers > 1
+                       then _id_hostname ++ "_" ++ show i
+                       else _id_hostname
+                ifaddr = (\(x,y,z,_) -> showIP (x, y, z, i)) _id_host_ip
+                ifaddrBMC = (\(x,y,z,_) -> showIP (x, y, z + 10, i)) _id_host_ip
             in CI.Enclosure {
-                  CI.enc_idx = i
+                  CI.enc_idx = fromIntegral i
                 , CI.enc_id = "enclosure_" ++ show i
-                , CI.enc_bmc = [CI.BMC (ifaddr_pfx ++ ".1") "admin" "admin"]
+                , CI.enc_bmc = [CI.BMC ifaddrBMC "admin" "admin"]
                 , CI.enc_hosts = [
                     CI.Host {
                       CI.h_fqdn = host
@@ -83,25 +115,25 @@ initialData host_pfx ifaddr_pfx n_srv n_drv globs = CI.InitialData {
                         }
                       ]
                     , CI.h_halon = Just $ CI.HalonSettings {
-                        CI._hs_address = host ++ "9000"
+                        CI._hs_address = ifaddr ++ ":9000"
                       , CI._hs_roles = []
                       }
                     }
                   ]
                 })
-          [(2 :: Int) .. n_srv + 1]
+          (take (fromIntegral _id_servers) $ iterate (+ 1) _id_servers)
       }
     ]
   , CI.id_m0_servers = fmap
-      (\i -> let
-          host = case n_srv of
-            1 -> host_pfx
-            _ -> host_pfx ++ "_" ++ show i
+      (\i -> let host = if _id_servers > 1
+                        then _id_hostname ++ "_" ++ show i
+                        else _id_hostname
+                 ifaddr = (\(x,y,z,_) -> showIP (x, y, z, i)) _id_host_ip
         in CI.M0Host {
             CI.m0h_fqdn = host
           , CI.m0h_processes = [
               CI.M0Process {
-                CI.m0p_endpoint = host ++ "@tcp:12345:41:901"
+                CI.m0p_endpoint = ifaddr ++ "@tcp:12345:41:901"
               , CI.m0p_mem_as = 1
               , CI.m0p_boot_level = 1
               , CI.m0p_mem_rss = 1
@@ -111,25 +143,25 @@ initialData host_pfx ifaddr_pfx n_srv n_drv globs = CI.InitialData {
               , CI.m0p_services = [
                   CI.M0Service {
                     CI.m0s_type = CST_MGS
-                  , CI.m0s_endpoints = [mgsEndpoint host]
+                  , CI.m0s_endpoints = [ifaddr ++ "@tcp:12345:44:101"]
                   , CI.m0s_params = SPConfDBPath "/var/mero/confd"
                   , CI.m0s_pathfilter = Nothing
                   }
                 , CI.M0Service {
                     CI.m0s_type = CST_RMS
-                  , CI.m0s_endpoints = [rmsEndpoint host]
+                  , CI.m0s_endpoints = [ifaddr ++ "@tcp:12345:41:301"]
                   , CI.m0s_params = SPUnused
                   , CI.m0s_pathfilter = Nothing
                     }
                 , CI.M0Service {
                     CI.m0s_type = CST_MDS
-                  , CI.m0s_endpoints = [mdsEndpoint host]
+                  , CI.m0s_endpoints = [ifaddr ++ "@tcp:12345:41:201"]
                   , CI.m0s_params = SPUnused
                   , CI.m0s_pathfilter = Nothing
                   }
                 , CI.M0Service {
                     CI.m0s_type = CST_IOS
-                  , CI.m0s_endpoints = [iosEndpoint host]
+                  , CI.m0s_endpoints = [ifaddr ++ "@tcp:12345:41:401"]
                   , CI.m0s_params = SPUnused
                   , CI.m0s_pathfilter = Nothing
                   }
@@ -142,26 +174,28 @@ initialData host_pfx ifaddr_pfx n_srv n_drv globs = CI.InitialData {
                       ("serial" ++ show i ++ show j)
                       4 64000
                       ("/dev/loop" ++ show i ++ show j))
-              [(1 :: Int) .. n_drv]
+              [(1 :: Int) .. _id_drives]
           })
-      [(2 :: Int) .. n_srv + 1]
+      (take (fromIntegral _id_servers) $ iterate (+ 1) _id_servers)
 }
 
-mgsEndpoint, rmsEndpoint, mdsEndpoint, iosEndpoint :: String  -> String
-mgsEndpoint host = unsafePerformIO $
-  fromMaybe (host ++ "@tcp:12345:44:101") <$> lookupEnv confdEndpoint
-rmsEndpoint host = unsafePerformIO $
-  fromMaybe (host ++ "@tcp:12345:41:301") <$> lookupEnv confdEndpoint
-mdsEndpoint host = unsafePerformIO $
-  fromMaybe (host ++ "@tcp:12345:41:201") <$> lookupEnv confdEndpoint
-iosEndpoint host = unsafePerformIO $
-  fromMaybe (host ++ "@tcp:12345:41:401") <$> lookupEnv confdEndpoint
+-- | Pre-populated 'InitialDataSettings'.
+defaultInitialDataSettings :: IO InitialDataSettings
+defaultInitialDataSettings = do
+  host <- getHostName
+  traverse readMaybe . splitOn "." <$> testListenName >>= \case
+    Just [x,y,z,w] -> return $ InitialDataSettings
+      { _id_hostname = host
+      , _id_host_ip = (x,y,z,w)
+      , _id_servers = 1
+      , _id_drives = 12
+      , _id_globals = defaultGlobals
+      }
+    r -> fail $ "Could not obtain host IP for initial data: " ++ show r
 
--- | Sample initial data for test purposes
-defaultInitialData :: CI.InitialData
-defaultInitialData = initialData host "192.0.2" 1 12 defaultGlobals
-  where host = unsafePerformIO $ do
-          mhost <- fmap (fst . (span (/=':'))) <$> lookupEnv "TEST_LISTEN"
-          case mhost of
-            Nothing -> getLnetNid
-            Just h  -> return h
+-- | Default initial data used through-out tests. To generate custom
+-- data, either use 'initialData' with custom 'InitialDataSettings' or
+-- work directly on modifying 'CI.InitialData' if you have already
+-- produced some.
+defaultInitialData :: IO CI.InitialData
+defaultInitialData = defaultInitialDataSettings >>= initialData

--- a/mero-halon/tests/TestRunner.hs
+++ b/mero-halon/tests/TestRunner.hs
@@ -106,24 +106,17 @@ withTrackingStation _ testRules action = do
   nid <- getSelfNode
   bracket
     (do
-      say "1"
       void $ EQT.startEQTracker [nid]
-      say "2"
       cEQGroup <- newRGroup $(mkStatic 'eqDict) "eqtest" 1000 1000000 4000000
                          [nid] emptyEventQueue
-      say "3"
       cMMGroup <- newRGroup $(mkStatic 'mmDict) "mmtest" 1000 1000000 4000000
                          [nid] (defaultMetaInfo, fromList [])
-      say "4"
       (,) <$> join (unClosure cEQGroup) <*> join (unClosure cMMGroup)
     )
     (\(g0, g1) -> killReplica g0 nid >> killReplica g1 nid)
     (\(eqGroup, mmGroup :: g (MetaInfo, Multimap)) -> do
-      say "5"
       eq <- startEventQueue (eqGroup :: g EventQueue)
-      say "6"
       (chan, rc) <- runRCEx (eq, [nid]) testRules mmGroup
-      say "7"
       action $ TestArgs eq chan rc
     )
 

--- a/mero-halon/tests/test-bootstrap.hs
+++ b/mero-halon/tests/test-bootstrap.hs
@@ -72,7 +72,7 @@ main = withMeroRoot $ \mero_root -> do
     hSetBuffering stderr LineBuffering
     hSetBuffering stdout LineBuffering
 
-    (ip, _) <- getTestListenSplit
+    ip <- testListenName
     setEnv "IP" ip
     let halon_sources = takeDirectory $ takeDirectory $ takeDirectory absSrcPath
     setEnv "HALON_SOURCES" halon_sources

--- a/mero-halon/tests/tests.hs
+++ b/mero-halon/tests/tests.hs
@@ -6,68 +6,47 @@
 
 module Main where
 
-import qualified HA.RecoveryCoordinator.Mero.Tests
-import qualified HA.RecoveryCoordinator.Tests
+import           Control.Concurrent (threadDelay, forkIO)
+import           Control.Concurrent.MVar
+import           Control.Exception
+import           Data.Proxy
 import qualified HA.Autoboot.Tests
+import qualified HA.Network.Socket as TCP
+import qualified HA.RecoveryCoordinator.Tests
+import           HA.Replicator.Log
+import           HA.Replicator.Mock
+import qualified HA.Test.Cluster
+import qualified HA.Test.Disconnect
+import qualified HA.Test.SSPL
+import           Helper.Environment
+import qualified Network.Socket as TCP
+import           Network.Transport (Transport, EndPointAddress)
+import qualified Network.Transport.TCP as TCP
+import           System.Directory (getCurrentDirectory)
+import           System.IO (hSetBuffering, BufferMode(..), stdout, stderr)
+import           Test.Framework
+import           Test.Tasty.HUnit (testCase)
+import           Test.Tasty.Ingredients.Basic (consoleTestReporter)
+import           Test.Tasty.Ingredients.FileReporter (fileTestReporter)
+
 #ifdef USE_MERO
 import qualified HA.RecoveryCoordinator.SSPL.Tests
 import qualified HA.Test.InternalStateChanges
 import qualified HA.Test.NotificationSort
 import qualified HA.Castor.Story.ProcessRestart
+import qualified HA.RecoveryCoordinator.Mero.Tests
 import qualified HA.Castor.Tests
 import qualified HA.Castor.Story.Tests
 #endif
-import HA.Replicator.Log
-import HA.Replicator.Mock
-import qualified HA.Test.Disconnect
-import qualified HA.Test.Cluster
-import qualified HA.Test.SSPL
 
-import Test.Tasty.Ingredients.Basic (consoleTestReporter)
-import Test.Tasty.Ingredients.FileReporter (fileTestReporter)
-
-import System.IO (hSetBuffering, BufferMode(..), stdout, stderr)
-
-import Network.Transport (Transport, EndPointAddress)
-
-import Helper.Environment
-import Test.Framework
-import Test.Tasty.HUnit (testCase)
-
-import Control.Concurrent (threadDelay, forkIO)
-import Control.Concurrent.MVar
-import Control.Exception
-import Data.Proxy
-
--- #ifdef USE_MERO
--- import Mero
--- #endif
-
-#ifdef USE_RPC
-import qualified Network.Transport.RPC as RPC
-import HA.Network.Transport (writeTransportGlobalIVar)
-#else
-import qualified HA.Network.Socket as TCP
-import qualified Network.Socket as TCP
-import qualified Network.Transport.TCP as TCP
-#endif
-import Prelude
-
-#ifdef USE_MERO
-#define MERO_TEST(K, S, X, D) (K (S) (X))
-#else
-#define MERO_TEST(K, S, X, D) (K (S ++ " [disabled due to unset USE_MERO]") (D))
-#endif
-
-
-tests :: String -> Transport -> (EndPointAddress -> EndPointAddress -> IO ()) -> IO TestTree
-tests host transport breakConnection = do
-    utests <- ut host transport breakConnection
-    itests <- it host transport breakConnection
+tests :: Transport -> (EndPointAddress -> EndPointAddress -> IO ()) -> IO TestTree
+tests transport breakConnection = do
+    utests <- ut transport
+    itests <- it transport breakConnection
     return $ testGroup "mero-halon" [utests, itests]
 
-ut :: String -> Transport -> (EndPointAddress -> EndPointAddress -> IO ()) -> IO TestTree
-ut _host transport _breakConnection = do
+ut :: Transport -> IO TestTree
+ut transport = do
   let pg = Proxy :: Proxy RLocalGroup
 #ifdef USE_MERO
   driveFailureTests <- HA.Castor.Story.Tests.mkTests pg
@@ -76,26 +55,19 @@ ut _host transport _breakConnection = do
 #endif
   return $ testGroup "tests with mock replicator"
       [ testGroup "RC" $ HA.RecoveryCoordinator.Tests.tests transport pg
-      , testGroup "mero" $
-          HA.RecoveryCoordinator.Mero.Tests.tests transport pg
-      , MERO_TEST(testGroup, "InternalStateChanges", internalSCTests transport
-                 , [testCase "Ignore me" $ return ()])
-      , MERO_TEST(testGroup,"Castor",HA.Castor.Tests.tests _host transport pg
-                 , [testCase "Ignore me" $ return ()])
-      , MERO_TEST( testGroup, "DriveFailure", driveFailureTests transport
-                 , [testCase "Ignore me" $ return ()])
-      , MERO_TEST(testGroup, "ProcessRestart", processRestartTests transport
-                 , [testCase "Ignore me" $ return ()])
-      , MERO_TEST( testGroup, "Service-SSPL"
-                 , HA.RecoveryCoordinator.SSPL.Tests.utTests transport pg
-                 , [testCase "Ignore me" $ return ()]
-                 )
-      , MERO_TEST( testGroup, "NotificationSort", HA.Test.NotificationSort.tests
-                 , [testCase "ignore me" $ return ()])
+#ifdef USE_MERO
+      , testGroup "mero" $ HA.RecoveryCoordinator.Mero.Tests.tests transport pg
+      , testGroup "InternalStateChanges" $ internalSCTests transport
+      , testGroup "Castor" $ HA.Castor.Tests.tests transport pg
+      , testGroup "DriveFailure" $ driveFailureTests transport
+      , testGroup "ProcessRestart" $ processRestartTests transport
+      , testGroup "Service-SSPL" $ HA.RecoveryCoordinator.SSPL.Tests.utTests transport pg
+      , testGroup "NotificationSort" HA.Test.NotificationSort.tests
+#endif
       ]
 
-it :: String -> Transport -> (EndPointAddress -> EndPointAddress -> IO ()) -> IO TestTree
-it _host transport breakConnection = do
+it :: Transport -> (EndPointAddress -> EndPointAddress -> IO ()) -> IO TestTree
+it transport breakConnection = do
   let pg = Proxy :: Proxy RLogGroup
   ssplTest <- HA.Test.SSPL.mkTests
 #ifdef USE_MERO
@@ -106,50 +78,36 @@ it _host transport breakConnection = do
   return $ testGroup "tests with log replicator"
       [ testCase "uncleanRPCClose" $ threadDelay 2000000
       , testGroup "RC" $ HA.RecoveryCoordinator.Tests.tests transport pg
-      , testGroup "Autoboot" $
-        HA.Autoboot.Tests.tests transport
+      , testGroup "Autoboot" $ HA.Autoboot.Tests.tests transport
       , HA.Test.Cluster.tests transport
-      , testGroup "mero" $
-          HA.RecoveryCoordinator.Mero.Tests.tests transport pg
-      , MERO_TEST(testGroup, "InternalStateChanges", internalSCTests transport
-                 , [testCase "Ignore me" $ return ()])
-      , MERO_TEST(testGroup,"Castor",HA.Castor.Tests.tests _host transport pg
-                 , [testCase "Ignore me" $ return ()])
-      , MERO_TEST( testGroup, "DriveFailure", driveFailureTests transport
-                 , [testCase "Ignore me" $ return ()])
-      , MERO_TEST(testGroup, "ProcessRestart", processRestartTests transport
-                 , [testCase "Ignore me" $ return ()])
-      , testGroup "disconnect" $
-        [ MERO_TEST(testCase, "testRejoinTimeout", HA.Test.Disconnect.testRejoinTimeout transport breakConnection, return ())
-        , MERO_TEST(testCase, "testRejoin", HA.Test.Disconnect.testRejoin transport breakConnection, return ())
-#if !defined(USE_RPC)
-        , testCase "testDisconnect" $
-            HA.Test.Disconnect.testDisconnect transport breakConnection
-#else
-        , testCase "testDisconnect [disabled by compilation flags]" $
-            const (return ()) $
-              HA.Test.Disconnect.testDisconnect transport breakConnection
+#ifdef USE_MERO
+      , testGroup "mero" $ HA.RecoveryCoordinator.Mero.Tests.tests transport pg
+      , testGroup "NotificationSort" HA.Test.NotificationSort.tests
+      , testGroup "InternalStateChanges" $ internalSCTests transport
+      , testGroup "Castor" $ HA.Castor.Tests.tests transport pg
+      , testGroup "DriveFailure" $ driveFailureTests transport
+      , testGroup "ProcessRestart" $ processRestartTests transport
 #endif
-        ]
+      , testGroup "disconnect" $
+#ifdef USE_MERO
+        [ testCase "testRejoinTimeout" $ HA.Test.Disconnect.testRejoinTimeout transport breakConnection
+        , testCase "testRejoin" $ HA.Test.Disconnect.testRejoin transport breakConnection
+        ] ++
+#endif
+        [ testCase "testDisconnect" $ HA.Test.Disconnect.testDisconnect transport breakConnection ]
       , ssplTest transport
       ]
 
 -- | Set up a 'Transport' and a way to break connections before
 -- passing it off to the given test tree.
-runTests :: (String -> Transport -> (EndPointAddress -> EndPointAddress -> IO ()) -> IO TestTree) -> IO ()
+runTests :: (Transport -> (EndPointAddress -> EndPointAddress -> IO ()) -> IO TestTree) -> IO ()
 runTests tests' = do
     -- TODO: Remove threadDelay after RPC transport closes cleanly
     hSetBuffering stdout LineBuffering
     hSetBuffering stderr LineBuffering
-    (host0, p0)<- getTestListenSplit
-    let addr0 = host0 ++ ":" ++ p0
-#ifdef USE_RPC
-    rpcTransport <- RPC.createTransport "s1"
-                       (RPC.rpcAddress addr0) RPC.defaultRPCParameters
-    writeTransportGlobalIVar rpcTransport
-    let transport = RPC.networkTransport rpcTransport
-        connectionBreak = undefined
-#else
+    Just (host0, p0)<- getTestListenSplit
+    let addr0 = host0 ++ ":" ++ show p0
+
     let TCP.SockAddrInet port hostaddr = TCP.decodeSocketAddress addr0
     hostname <- TCP.inet_ntoa hostaddr
     (transport, internals) <- either (error . show) id <$>
@@ -170,14 +128,17 @@ runTests tests' = do
             TCP.socketBetween internals here there >>= TCP.close
           ignoreSyncExceptions $
             TCP.socketBetween internals there here >>= TCP.close
-#endif
     defaultMainWithIngredients [fileTestReporter [consoleTestReporter]]
-      =<< tests' host0 transport connectionBreak
+      =<< tests' transport connectionBreak
 
 main :: IO ()
-main = prepare $ runTests tests where
+main = prepare $ do
+  dir <- getCurrentDirectory
+  putStrLn $ "Running tests in " ++ dir
+  runTests tests
+  where
 #ifdef USE_MERO
-  prepare = withTmpDirectory
+    prepare = withTmpDirectory
 #else
-  prepare = id
+    prepare = id
 #endif

--- a/mero-halon/tests/wrapper
+++ b/mero-halon/tests/wrapper
@@ -1,5 +1,0 @@
-#!/bin/bash -e
-R=${HA_RPC_FOLDER:-tmp-HA-test-${RANDOM}}
-mkdir -p $R
-cd $R
-$*


### PR DESCRIPTION
*Created by: Fuuzetsu*

Recent changes have crippled many of the tests. For example, initial
data validation feature implemented recently exposed that the initial
data used in tests was more often than not just outright malformed. The
way data is created in tests has been somewhat refactored. Tests have
been adjusted accordingly. Some tests had to be adjusted (i.e. remove
hard-coded values) for the new data.

`testDriveAddition` was removed completelly. It was redundant. Minor
fixes here and there: drop unused parameters, demote some messages to
`usend` instead of `promulgate` where `promulgate` is unnecessary,
remove or inline some unnecessary helpers, rearrange some import lists &c.