### PR TITLE
[HALON-574] Async controlProcess commands

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -171,7 +171,8 @@ Library
                    lens,
                    vinyl,
                    gitrev,
-                   inline-c
+                   inline-c,
+                   bimap
 
   if flag(mero)
       c-sources:       src/lib/Version/Read.c

--- a/mero-halon/src/lib/HA/Services/Mero/Types.hs
+++ b/mero-halon/src/lib/HA/Services/Mero/Types.hs
@@ -121,7 +121,7 @@ instance Hashable NotificationMessage
 data ProcessRunType =
     M0D -- ^ Run 'm0d' service.
   | M0T1FS -- ^ Run 'm0t1fs' service.
-  deriving (Eq, Show, Typeable, Generic)
+  deriving (Ord, Eq, Show, Typeable, Generic)
 instance Binary ProcessRunType
 instance Hashable ProcessRunType
 
@@ -133,7 +133,7 @@ data ProcessConfig =
     -- ^ Process fid, endpoint, conf.xc
   | ProcessConfigRemote M0.Process
   -- ^ Process fid, endpoint
-  deriving (Eq, Show, Typeable, Generic)
+  deriving (Ord, Eq, Show, Typeable, Generic)
 instance Binary ProcessConfig
 instance Hashable ProcessConfig
 
@@ -142,7 +142,7 @@ data ProcessControlMsg =
     StartProcess ProcessRunType M0.Process
   | StopProcess ProcessRunType M0.Process
   | ConfigureProcess ProcessRunType ProcessConfig Bool
-  deriving (Eq, Show, Typeable, Generic)
+  deriving (Ord, Eq, Show, Typeable, Generic)
 instance Binary ProcessControlMsg
 instance Hashable ProcessControlMsg
 


### PR DESCRIPTION
*Created by: Fuuzetsu*

Spawn systemctl commands on nodes asynchronously. This means processes
on same boot-level no longer have to wait on each other. This should
speed up concurrent process start/stop (bootstrap/teardown) and greatly
reduce the risk of bogus process rule timeouts.

We check the commands being ran for uniqueness: if we're handling a
certain request already, we won't do it again if the process for that
command is still running. We keep a map of running processes. Note that
nothing stops us here from running stop and start commands at once for
example: the user has to make sure that the issued control commands are
sane.

In the near future, perhaps an "abort" control command is in order: the
rules could request that we kill the running command as part of
clean-up. This means we won't have late message results coming (modulo a
small race of abort command being sent and actually processed which
should be OK: rule can account for this) and we can be assured that if
we're requesting process start, our environment is somewhat sane if
process stop rule has previously failed.