### PR TITLE
[HALON-515] halon-cleanup systemd service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ m0trace.*
 core
 core.*
 /tags
-/TAGS
+TAGS
 /cscope.*
 /ncscope.*
 GPATH

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,10 @@ rpm-dev:
 	mkdir -p rpmbuild/SOURCES/tmpfiles.d
 	cp .stack-work/install/x86_64-linux/lts-5.17/7.10.3/bin/halond rpmbuild/SOURCES/
 	cp .stack-work/install/x86_64-linux/lts-5.17/7.10.3/bin/halonctl rpmbuild/SOURCES/
+	cp .stack-work/install/x86_64-linux/lts-5.17/7.10.3/bin/halon-cleanup rpmbuild/SOURCES/
 	cp systemd/halond.service rpmbuild/SOURCES/
 	cp systemd/halon-satellite.service rpmbuild/SOURCES/
+	cp systemd/halon-cleanup.service rpmbuild/SOURCES/
 	cp mero-halon/scripts/localcluster rpmbuild/SOURCES/halon-simplelocalcluster
 	cp mero-halon/scripts/hctl rpmbuild/SOURCES/hctl
 	cp mero-halon/scripts/mero_role_mappings.ede rpmbuild/SOURCES/role_maps/genders.ede

--- a/halon-dev.spec
+++ b/halon-dev.spec
@@ -27,8 +27,10 @@ cp $RPM_SOURCE_DIR/halonctl $RPM_BUILD_DIR/halon
 cp $RPM_SOURCE_DIR/halond $RPM_BUILD_DIR/halon
 cp $RPM_SOURCE_DIR/halon-simplelocalcluster $RPM_BUILD_DIR/halon
 cp $RPM_SOURCE_DIR/hctl $RPM_BUILD_DIR/halon
+cp $RPM_SOURCE_DIR/halon-cleanup $RPM_BUILD_DIR/halon
 cp $RPM_SOURCE_DIR/halond.service $RPM_BUILD_DIR/systemd
 cp $RPM_SOURCE_DIR/halon-satellite.service $RPM_BUILD_DIR/systemd
+cp $RPM_SOURCE_DIR/halon-cleanup.service $RPM_BUILD_DIR/systemd
 cp $RPM_SOURCE_DIR/role_maps/* $RPM_BUILD_DIR/role_maps
 cp $RPM_SOURCE_DIR/tmpfiles.d/* $RPM_BUILD_DIR/tmpfiles.d
 
@@ -41,8 +43,13 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/lib/systemd/system
 mkdir -p %{buildroot}/etc/halon/role_maps
+mkdir -p %{buildroot}/usr/libexec/halon
 mkdir -p %{buildroot}%{_tmpfilesdir}
-cp -a $RPM_BUILD_DIR/halon/* %{buildroot}/usr/bin
+cp -a $RPM_BUILD_DIR/halon/halond %{buildroot}/usr/bin
+cp -a $RPM_BUILD_DIR/halon/halonctl %{buildroot}/usr/bin
+cp -a $RPM_BUILD_DIR/halon/halon-simplelocalcluster %{buildroot}/usr/bin
+cp -a $RPM_BUILD_DIR/halon/hctl %{buildroot}/usr/bin
+cp -a $RPM_BUILD_DIR/halon/halon-cleanup %{buildroot}/usr/libexec/halon
 cp -a $RPM_BUILD_DIR/systemd/* %{buildroot}/usr/lib/systemd/system
 cp -a $RPM_BUILD_DIR/role_maps/* %{buildroot}/etc/halon/role_maps
 cp -a $RPM_BUILD_DIR/tmpfiles.d/* %{buildroot}%{_tmpfilesdir}
@@ -59,8 +66,10 @@ rm -rf %{buildroot}
 /usr/bin/halonctl
 /usr/bin/halon-simplelocalcluster
 /usr/bin/hctl
+/usr/libexec/halon/halon-cleanup
 /usr/lib/systemd/system/halond.service
 /usr/lib/systemd/system/halon-satellite.service
+/usr/lib/systemd/system/halon-cleanup.service
 /etc/halon/role_maps/genders.ede
 /etc/halon/role_maps/prov.ede
 /etc/halon/mero_role_mappings

--- a/halon.spec
+++ b/halon.spec
@@ -44,9 +44,11 @@ mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/lib/systemd/system
 mkdir -p %{buildroot}/etc/halon/role_maps
 mkdir -p %{buildroot}/etc/logrotate.d
+mkdir -p %{buildroot}/usr/libexec/halon
 mkdir -p %{buildroot}%{_tmpfilesdir}
 cp $(%{stack} path --local-install-root)/bin/halonctl %{buildroot}/usr/bin
 cp $(%{stack} path --local-install-root)/bin/halond %{buildroot}/usr/bin
+cp $(%{stack} path --local-install-root)/bin/halon-cleanup %{buildroot}/usr/libexec/halon
 cp systemd/*.service %{buildroot}/usr/lib/systemd/system
 cp mero-halon/scripts/logrotate %{buildroot}/etc/logrotate.d/halon
 cp mero-halon/scripts/hctl %{buildroot}/usr/bin/hctl
@@ -68,8 +70,10 @@ rm -rf %{buildroot}
 /usr/bin/halond
 /usr/bin/halonctl
 /usr/bin/hctl
+/usr/libexec/halon/halon-cleanup
 /usr/lib/systemd/system/halond.service
 /usr/lib/systemd/system/halon-satellite.service
+/usr/lib/systemd/system/halon-cleanup.service
 /etc/halon/role_maps/genders.ede
 /etc/halon/role_maps/prov.ede
 /etc/halon/mero_role_mappings

--- a/halon/src/lib/System/SystemD/API.hs
+++ b/halon/src/lib/System/SystemD/API.hs
@@ -72,6 +72,10 @@ startService srv = do
 stopService :: String -> IO ExitCode
 stopService = doService "stop"
 
+-- | Get exit code of @systemctl status@ for the given service.
+statusService :: String -> IO ExitCode
+statusService = doService "status"
+
 -- | Restart the service with the given name
 restartService :: String -> IO (Either Int (Maybe Int))
 restartService srv = do

--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -375,6 +375,19 @@ Executable halond
       Build-Depends: network >= 2.4,
                      network-transport-tcp >= 0.3.1
 
+
+Executable halon-cleanup
+  Hs-Source-Dirs:     src/halon-cleanup
+  Main-Is:            Main.hs
+
+  Ghc-Options: -threaded -Wall -g -Werror
+
+  default-language:   Haskell2010
+  Build-Depends:      base >= 4.5,
+                      directory,
+                      halon,
+                      process
+
 Test-Suite distributed-tests
   Type:             exitcode-stdio-1.0
   default-language: Haskell2010
@@ -454,19 +467,6 @@ Test-Suite testepoch
 
   if flag(maintainer)
     Ghc-Options: -Werror
-
---  if flag(rpc) && flag(mero)
---    Build-Depends:   halon,
---                     mero-halon,
---                     base >= 4.5,
---                     directory,
---                     filepath,
---                     process >= 1.1,
---                     process >= 1.1,
---                     binary >= 0.6.4,
---                     network-transport-rpc,
---                     time >= 1.4
---  else
   buildable: False
 
 Test-Suite testeventqueue

--- a/mero-halon/src/halon-cleanup/Main.hs
+++ b/mero-halon/src/halon-cleanup/Main.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE LambdaCase #-}
+-- |
+-- Module    : Main
+-- Copyright : 2016 Seagate Technology Limited.
+-- License   : All rights reserved.
+--
+-- @halon-cleanup.service@ driver. It is not intended to be ran
+-- manually but through the service.
+module Main (main) where
+
+import Control.Monad (void, when)
+import Data.Foldable (for_)
+import Data.Maybe (mapMaybe)
+import Data.Monoid ((<>))
+import HA.Replicator.Log (storageDir)
+import Prelude hiding (log)
+import System.Directory
+import System.Exit
+import System.IO
+import System.Process
+import System.SystemD.API (stopService, statusService)
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+
+-- | @'hPutStrLn' 'stdout'@
+log :: String -> IO ()
+log = hPutStrLn stdout
+
+main :: IO ()
+main = do
+  -- Find PIDs of halond process(es) but don't do anything with them
+  -- yet.
+  log "Searching for halond processes."
+  pids <- pidof "halond" >>= \case
+    Left err -> do
+      hPutStrLn stderr err
+      return []
+    Right pids -> do
+      return pids
+  -- Kill any halonctl instances that may be running.
+  log "Killing any halonctl processes."
+  pidof "halonctl" >>= \case
+    Right pids'@(_ : _) ->
+      void $ readProcessWithExitCodeVerbose "kill" ("-9" : map show pids')
+    _ -> return ()
+  -- Ask systemd to stop halond service if any is running. Assumption
+  -- is that halond was started through systemd service.
+  log "Stopping halond, if any."
+  when (not $ null pids) $ do
+    statusService "halond.service" >>= \case
+      ExitSuccess -> stopService "halond.service" >>= \case
+        ExitSuccess -> return ()
+        ExitFailure rc -> do
+          hPutStrLn stderr $ "halond.service stop failed with " <> show rc
+          log "Trying to kill halond manually."
+          void $ readProcessWithExitCodeVerbose "kill" ("-9" : map show pids)
+      ExitFailure{} -> do
+        log "halond service not running, killing halond manually."
+        void $ readProcessWithExitCodeVerbose "kill" ("-9" : map show pids)
+    -- Remove any m0trace files under /var/log that belong to halond
+    -- PIDs we identified earlier.
+    log "Removing halond m0trace files."
+    for_ pids $ \p -> do
+      removeFileIfExists $ printf "m0trace.%d" p
+      removeFileIfExists $ printf "/var/log/m0trace.%d" p
+  -- Remove persistent storage, if any. Maybe we should randomly try
+  -- other directories such as /var/log and /var/lib/halon too. We
+  -- could do better if /etc/sysconfig/halond set HALON_PERSISTENCE
+  -- and if halond.service was always used.
+  log $ "Trying to remove persistent storage data from common locations."
+  removeDirectoryRecursiveIfExists storageDir
+  removeDirectoryRecursiveIfExists "/var/log/halon-persistence"
+  removeDirectoryRecursiveIfExists "/var/lib/halon/halon-persistence"
+  -- Check for decision-log output in default locations specified by
+  -- halon_roles.yaml. If they aren't there, just do nothing; not much
+  -- we can do to get this information from elsewhere.
+  removeFileIfExists "/var/log/halon.decision.log"
+  removeFileIfExists "/var/log/halon.trace.log"
+  -- bootstrap-cluster script usually puts things in /tmp/halond.log
+  -- so try removing that too; once the script stops being used, we
+  -- should remove this.
+  removeFileIfExists "/tmp/halond.log"
+  exitSuccess
+
+-- | Remove the given file if it exists. Allow any exceptions to
+-- propagate freely.
+removeFileIfExists :: FilePath -> IO ()
+removeFileIfExists fp = doesFileExist fp >>= \case
+  True -> do
+    log $ "Removing " <> fp
+    removeFile fp
+  False -> log $ printf "%s not found, not removing." fp
+
+-- | Recursively remove specified directory if it exists.
+removeDirectoryRecursiveIfExists :: FilePath -> IO ()
+removeDirectoryRecursiveIfExists fp = doesDirectoryExist fp >>= \case
+  True -> do
+    log $ "Removing " <> fp
+    removeDirectoryRecursive fp
+  False -> log $ printf "%s not found, not removing." fp
+
+-- | 'readProcessWithExitCode' but announces the command on 'stdout'
+-- first. Does not provide any input to the process.
+readProcessWithExitCodeVerbose :: FilePath -> [String] -> IO (ExitCode, String, String)
+readProcessWithExitCodeVerbose cmd args = do
+  hPutStrLn stdout . unwords $ "Running:" : cmd : args
+  readProcessWithExitCode cmd args ""
+
+-- | Run @pidof@ command for the given process and try to parse the results.
+pidof :: String -> IO (Either String [Int])
+pidof p = do
+  (ec, sout, _) <- readProcessWithExitCodeVerbose "pidof" [p]
+  return $ case ec of
+    ExitSuccess -> case map words $ lines sout of
+      pids : _ -> case mapMaybe readMaybe pids of
+        [] -> Left $ "Could not parse ‘" <> sout <> "’ into pids."
+        pids' -> Right pids'
+      [] -> Right []
+    ExitFailure rc -> Left $ "pidof failed with " <> show rc

--- a/systemd/halon-cleanup.service
+++ b/systemd/halon-cleanup.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Halon cleanup service
+Documentation=https://github.com/seagate-ssg/halon
+
+[Service]
+EnvironmentFile=/etc/sysconfig/halond
+Type=oneshot
+ExecStart=/usr/libexec/halon/halon-cleanup


### PR DESCRIPTION
*Created by: Fuuzetsu*

With some files we don't have good idea of where they could be, depending on how cluster was started &c. We guess common locations. In future, things should be set in /etc/sysconfig/halond so we can just look there and not worry about other places.