### PR TITLE
[HALON-590] Give leveldb a chance to finish writes

### DIFF
--- a/mero-halon/tests/HA/RecoveryCoordinator/SSPL/Tests.hs
+++ b/mero-halon/tests/HA/RecoveryCoordinator/SSPL/Tests.hs
@@ -271,6 +271,8 @@ testDMRequest = mkHpiTest rules test
         uuid5 <- liftIO $ nextRandom
         usend rc $ HAEvent uuid5 (me, request5)
         liftIO . assertEqual "OK_None smart for bad" "drive-ok" =<< await uuid5
+
+        _ <- receiveTimeout 2000000 [] -- HALON-590
         return ()
       where
         await uuid = receiveWait


### PR DESCRIPTION
*Created by: Fuuzetsu*

We see a segfault on write in leveldb with drive-manager-works test. The
test is sensitive to changes: if we add any delays or change some
messages, we stop failing. I suspect it's because something (trim?)
keeps writing to the db; meanwhile the test finished and `unsafeClose`
is called on the db handle. If this is the case then it's unclear how to
fix this properly: perhaps we need to set some value in replicated-log
when writes are happening and block db close on until after writes are
finished.

In meantime, just add a small timeout to unblock master.