### PR TITLE
[HALON-588] Allow m0t1fs to be started on any boot level

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero.hs
@@ -235,7 +235,7 @@ calculateStopLevel = do
       -- We allow stopping a process on level i if there are no running
       -- processes on level i+1
       stillUnstopped <- getLocalGraph <&>
-        getLabeledProcesses (M0.PLBootLevel . M0.BootLevel $ 1)
+        getLabeledProcesses (M0.PLBootLevel $ M0.BootLevel 1)
           ( \p g -> not . null $
           [ () | M0.getState p g `elem` [ M0.PSOnline
                                         , M0.PSQuiescing

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Process/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Process/Rules.hs
@@ -143,9 +143,9 @@ ruleProcessStart = mkJobRule jobProcessStart args $ \(JobHandle getRequest finis
         rg <- getLocalGraph
         case runChecks p rg of
           Just chkFailMsg ->
-            Right <$> (defaultReply ProcessStartInvalid) chkFailMsg
+            Right <$> defaultReply ProcessStartInvalid chkFailMsg
           Nothing -> initResources p rg >>= \case
-            Just failMsg -> Right <$> (defaultReply ProcessStartFailed) failMsg
+            Just failMsg -> Right <$> defaultReply ProcessStartFailed failMsg
             Nothing -> do
               forM_ (runWarnings p rg) $ phaseLog "warn"
 
@@ -348,7 +348,8 @@ ruleProcessStart = mkJobRule jobProcessStart args $ \(JobHandle getRequest finis
       Just (_, M0.MeroClusterState M0.OFFLINE _ _) ->
         (False, "Cluster disposition is offline")
       Just (pl, M0.MeroClusterState M0.ONLINE rl _) ->
-        (rl >= pl, printf "Can't start %s on cluster boot level %s" (showFid p) (show rl))
+        ( rl >= pl || G.isConnected p Has M0.PLM0t1fs rg
+        , printf "Can't start %s on cluster boot level %s" (showFid p) (show rl))
 
     checkIsNotHA p rg =
       let srvs = G.connectedTo p M0.IsParentOf rg


### PR DESCRIPTION
*Created by: Fuuzetsu*

In regular bootstrap, we still only start it once the cluster has
entered level 2; however if the user requests the process start
manually (or we enter process start rule through some other means), we
let m0t1fs to start on any boot level.