### PR TITLE
[HALON-583] Increase timeouts related to process stop

### DIFF
--- a/mero-halon/src/halonctl/Handler/Cluster.hs
+++ b/mero-halon/src/halonctl/Handler/Cluster.hs
@@ -393,7 +393,7 @@ parseStopOptions = StopOptions
     ( Opt.metavar "TIMEOUT(µs)"
     <> Opt.long "timeout"
     <> Opt.help "How long to wait for successful cluster stop before halonctl gives up on waiting."
-    <> Opt.value 300000000
+    <> Opt.value 600000000
     <> Opt.showDefault )
 
 parseMkfsDoneOptions :: Opt.Parser MkfsDoneOptions

--- a/mero-halon/src/lib/HA/Resources/HalonVars.hs
+++ b/mero-halon/src/lib/HA/Resources/HalonVars.hs
@@ -34,12 +34,12 @@ defaultHalonVars = HalonVars
   , _hv_process_configure_timeout = 300
   , _hv_process_start_cmd_timeout = 300
   , _hv_process_start_timeout = 180
-  , _hv_process_stop_timeout = 120
+  , _hv_process_stop_timeout = 600
   , _hv_process_max_start_attempts = 5
   , _hv_process_restart_retry_interval = 5
   , _hv_mero_kernel_start_timeout = 300
   , _hv_clients_start_timeout = 600
-  , _hv_node_stop_barrier_timeout = 180
+  , _hv_node_stop_barrier_timeout = 600
   }
 
 -- | Get 'HalonVars' from RG


### PR DESCRIPTION
*Created by: Fuuzetsu*

Increase timeout for systemctl stop command. This impacts at what rate
will timing out processes be reported back to cluster stop rule so
increase a barrier timeout too; for the same reason increase how long
halonctl should wait for cluster stop to happen: this value is already
technically too low because we have multiple bootlevels but it will have
to do.

A future task should be the removal of barrier timeout all together:
it's not necessary if process stop rule always returns *and* we don't
want to ‘skip ahead’ in cluster teardown if some processes are slow.