### PR TITLE
[HALON-593] Remove `HA.ResourceGraph.newResource`

### DIFF
--- a/halon/benchmarks/gc-rg.hs
+++ b/halon/benchmarks/gc-rg.hs
@@ -96,8 +96,7 @@ mkGCGraph f = f $ emptyGraph mmchan
 buildGraph :: Int -- ^ Number of nodes in graph
            -> ConnectFilter -- ^ Edges to connect in the graph
            -> Graph -> Graph
-buildGraph n p = addRootNode (NodeA 1) . addEdges . addResources where
-  addResources g0 = foldl' (\g n' -> newResource (NodeA n') g) g0 [1 .. n]
+buildGraph n p = addRootNode (NodeA 1) . addEdges where
   addEdges g0 = foldl' (\g (a, b) -> connect (NodeA a) (EdgeA 0) (NodeA b) g) g0
               $ p n
 

--- a/halon/benchmarks/sync-rg.hs
+++ b/halon/benchmarks/sync-rg.hs
@@ -159,8 +159,7 @@ testSyncLarge t n = rGroupTest t g $ \pid -> do
     g = undefined :: MC_RG Multimap
 
 buildCompleteGraph :: Int -> Graph -> Graph
-buildCompleteGraph n = addResources . addEdges where
-  addResources = foldl' (.) id $ fmap (newResource . NodeA) range
+buildCompleteGraph n = addEdges where
   addEdges = foldl' (.) id
               $ fmap (\(a,b) -> connect (NodeA a) EdgeA (NodeA b))
               $ pairs range

--- a/halon/src/lib/HA/ResourceGraph.hs
+++ b/halon/src/lib/HA/ResourceGraph.hs
@@ -47,7 +47,6 @@ module HA.ResourceGraph
     , Cardinality(..)
     -- , Quantify(..)
     -- * Operations
-    , newResource
     , insertEdge
     , deleteEdge
     , connect
@@ -369,17 +368,6 @@ outFromEdge Edge{..} = OutRel edgeRelation edgeSrc edgeDst
 
 inFromEdge :: Relation r a b => Edge a r b -> Rel
 inFromEdge Edge{..} = InRel edgeRelation edgeSrc edgeDst
-
--- | Register a new resource. A resource is meant to be immutable: it does not
--- change and lives forever.
-newResource :: Resource a => a -> Graph -> Graph
-newResource x g =
-    g { grChangeLog = updateChangeLog (InsertMany [ (encodeRes (Res x),[]) ])
-                                      (grChangeLog g)
-      , grGraph = M.insertWith combineRes (Res x) S.empty $ grGraph g
-      }
-  where
-    combineRes _ es = es
 
 -- | Connect source and destination resources through a directed edge.
 insertEdge :: Relation r a b => Edge a r b -> Graph -> Graph

--- a/halon/tests/HA/ResourceGraph/Tests/Merge.hs
+++ b/halon/tests/HA/ResourceGraph/Tests/Merge.hs
@@ -70,14 +70,13 @@ newtype GraphBuilder = GraphBuilder (Graph -> Graph)
 instance Arbitrary GraphBuilder where
   arbitrary = do
     resources <- listOf1 (arbitrary :: Gen Node)
-    relCount <- arbitrary
+    relCount <- suchThat arbitrary (> 0)
     relations <- replicateM relCount $ do
       from <- elements resources
       to <- elements resources
       return (from, to)
     return . GraphBuilder
-      $ (foldl' (.) id (newResource <$> resources))
-      . (foldl' (.) id ((\(f, t) -> connect f Link t) <$> relations))
+      $ foldl' (.) id ((\(f, t) -> connect f Link t) <$> relations)
 
 instance Arbitrary MergeTest where
   arbitrary = do

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero.hs
@@ -90,13 +90,9 @@ rmsAddress = ":12345:41:301"
 createMeroKernelConfig :: Castor.Host
                        -> String -- ^ LNet interface address
                        -> PhaseM RC a ()
-createMeroKernelConfig host lnid = modifyLocalGraph $ \rg -> do
+createMeroKernelConfig host lnid = do
   uuid <- liftIO nextRandom
-  return  $ G.newResource uuid
-        >>> G.newResource (M0.LNid lnid)
-        >>> G.connect host Has (M0.LNid lnid)
-        >>> G.connect host Has uuid
-          $ rg
+  modifyGraph $ G.connect host Has uuid . G.connect host Has (M0.LNid lnid)
 
 -- | Create relevant configuration for a mero client in the RG.
 --
@@ -149,11 +145,7 @@ createMeroClientConfig fs host (HostHardwareInfo memsize cpucnt nid) = do
                             <*> pure [nid ++ haAddress]
                             <*> pure SPUnused
     -- Create graph
-    let rg' = G.newResource m0node
-          >>> G.newResource process
-          >>> G.newResource rmsService
-          >>> G.newResource haService
-          >>> G.connect m0node M0.IsParentOf process
+    let rg' = G.connect m0node M0.IsParentOf process
           >>> G.connect process M0.IsParentOf rmsService
           >>> G.connect process M0.IsParentOf haService
           >>> G.connect process Has M0.PLM0t1fs

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Test.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Test.hs
@@ -23,14 +23,10 @@ getNoisyPingCount = do
     rg <- getLocalGraph
     let (rg', i) =
           case G.connectedTo noisy HasPingCount rg of
-            Nothing ->
-              let nrg = G.connect noisy HasPingCount (NoisyPingCount 0) $
-                        G.newResource (NoisyPingCount 0) rg in
-              (nrg, 0)
+            Nothing -> (G.connect noisy HasPingCount (NoisyPingCount 0) rg, 0)
             Just pc@(NoisyPingCount iPc) ->
               let newPingCount = NoisyPingCount (iPc + 1)
                   nrg = G.connect noisy HasPingCount newPingCount $
-                        G.newResource newPingCount $
                         G.disconnect noisy HasPingCount pc rg in
               (nrg, iPc)
     putLocalGraph rg'

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero.hs
@@ -23,7 +23,6 @@ module HA.RecoveryCoordinator.Mero
        , labelRecoveryCoordinator
        ) where
 
-import           Control.Category
 import           Control.Distributed.Process
 import           Data.Binary (Binary)
 import           Data.Dynamic
@@ -72,15 +71,14 @@ ack pid = liftProcess $ usend pid ()
 initialize :: StoreChan -> Process G.Graph
 initialize mm = do
     rg <- G.getGraph mm
-    if G.null rg then say "Starting from empty graph."
-                 else say "Found existing graph."
     -- Empty graph means cluster initialization.
-    let rg' | G.null rg =
-            G.newResource Cluster >>>
-            G.addRootNode Cluster
-            $ rg
-            | otherwise = rg
-    return rg'
+    if G.null rg
+    then do
+      say "Starting from empty graph."
+      return $! G.addRootNode Cluster rg
+    else do
+      say "Found existing graph."
+      return rg
 
 ----------------------------------------------------------
 -- Recovery Co-ordinator                                --

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Actions/Spiel.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Actions/Spiel.hs
@@ -71,7 +71,6 @@ import Mero.ConfC (Fid)
 import Mero.M0Worker
 
 import Control.Applicative
-import Control.Category ((>>>))
 import qualified Control.Distributed.Process as DP
 import Control.Monad (void, join)
 import Control.Monad.Catch
@@ -512,7 +511,7 @@ getConfUpdateVersion = do
     Just ver -> return ver
     Nothing -> do
       let csu = M0.ConfUpdateVersion 1 Nothing
-      modifyLocalGraph $ G.newResource csu >>> return . G.connect Cluster Has csu
+      modifyGraph $ G.connect Cluster Has csu
       return csu
 
 modifyConfUpdateVersion :: (M0.ConfUpdateVersion -> M0.ConfUpdateVersion)

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Failure/Internal.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Failure/Internal.hs
@@ -100,16 +100,13 @@ createPoolVersionsInPool fs pool pvers invert rg =
                         <*> pure (M0.PVerActual (failuresToArray failures)
                                                 (attrs { _pa_P = fromIntegral width }))
         rg0 <- S.get
-        S.modify'
-            $ G.newResource pver
-          >>> G.connect pool M0.IsRealOf pver
+        S.modify' $ G.connect pool M0.IsRealOf pver
         i <- for (filter (test fids)
                  $ G.connectedTo fs M0.IsParentOf rg0 :: [M0.Rack]) $ \rack -> do
                rackv <- M0.RackV <$> S.state (newFid (Proxy :: Proxy M0.RackV))
                rg1 <- S.get
                S.modify'
-                   $ G.newResource rackv
-                 >>> G.connect pver M0.IsParentOf rackv
+                   $ G.connect pver M0.IsParentOf rackv
                  >>> G.connect rack M0.IsRealOf rackv
                i <- for (filter (test fids)
                         $ G.connectedTo rack M0.IsParentOf rg1 :: [M0.Enclosure])
@@ -117,8 +114,7 @@ createPoolVersionsInPool fs pool pvers invert rg =
                       enclv <- M0.EnclosureV <$> S.state (newFid (Proxy :: Proxy M0.EnclosureV))
                       rg2 <- S.get
                       S.modify'
-                          $ G.newResource enclv
-                        >>> G.connect rackv M0.IsParentOf enclv
+                          $ G.connect rackv M0.IsParentOf enclv
                         >>> G.connect encl M0.IsRealOf enclv
                       i <- for (filter (test fids)
                                $ G.connectedTo encl M0.IsParentOf rg2 :: [M0.Controller])
@@ -126,16 +122,14 @@ createPoolVersionsInPool fs pool pvers invert rg =
                              ctrlv <- M0.ControllerV <$> S.state (newFid (Proxy :: Proxy M0.ControllerV))
                              rg3 <- S.get
                              S.modify'
-                                 $ G.newResource ctrlv
-                               >>> G.connect enclv M0.IsParentOf ctrlv
+                                 $ G.connect enclv M0.IsParentOf ctrlv
                                >>> G.connect ctrl M0.IsRealOf ctrlv
                              let disks = filter (test fids) $
                                    G.connectedTo ctrl M0.IsParentOf rg3 :: [M0.Disk]
                              for_ disks $ \disk -> do
                                diskv <- M0.DiskV <$> S.state (newFid (Proxy :: Proxy M0.DiskV))
                                S.modify'
-                                    $ G.newResource diskv
-                                  >>> G.connect ctrlv M0.IsParentOf diskv
+                                    $ G.connect ctrlv M0.IsParentOf diskv
                                   >>> G.connect disk M0.IsRealOf diskv
                              return (not $ null disks)
                       unless (or i) $ S.put rg2

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Actions.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Actions.hs
@@ -24,7 +24,6 @@ module HA.RecoveryCoordinator.RC.Actions
   , module HA.RecoveryCoordinator.RC.Actions.Core
   ) where
 
-import           Control.Category ((>>>))
 import           Control.Distributed.Process hiding (try)
 import           Control.Distributed.Process.Closure (mkClosure)
 import           Control.Distributed.Process.Internal.Types (SpawnRef, nullProcessId)
@@ -82,14 +81,8 @@ makeCurrentRC update = do
          update old currentRC
   return currentRC
   where
-    mkRC = modifyGraph $ \g ->
-      let g' = G.newResource currentRC
-           >>> G.newResource R.Active
-           >>> G.connect R.Cluster R.Has currentRC
-           >>> G.connect currentRC R.Is R.Active
-             $ g
-      in g'
-
+    mkRC = modifyGraph $ G.connect currentRC R.Is R.Active
+                       . G.connect R.Cluster R.Has currentRC
 
 -- | Find currenlty running RC in resource graph.
 tryGetCurrentRC :: PhaseM RC l (Maybe R.RC)

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Actions/Core.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Actions/Core.hs
@@ -79,7 +79,6 @@ import           Control.Distributed.Process
   , link
   )
 import           Control.Distributed.Process.Serializable
-import           Control.Category ((>>>))
 import           Control.Monad (when, unless, (<=<))
 import           Data.Functor (void)
 import qualified Data.Map.Strict as Map
@@ -166,13 +165,9 @@ knownResource res = fmap (G.memberResource res) getLocalGraph
 
 -- | Register a new satellite node in the cluster.
 registerNode :: Node -> PhaseM RC l ()
-registerNode node = modifyLocalGraph $ \rg -> do
-    phaseLog "rg" $ "Registering satellite node: " ++ show node
-
-    let rg' = G.newResource node >>>
-              G.connect Cluster Has node $ rg
-
-    return rg'
+registerNode node = do
+  phaseLog "rg" $ "Registering satellite node: " ++ show node
+  modifyGraph $ G.connect Cluster Has node
 
 -- | Retrieve the Resource 'G.Graph' from the 'Global' state.
 getLocalGraph :: PhaseM RC l G.Graph

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Rules.hs
@@ -100,15 +100,10 @@ ruleNewSubscription = defineSimpleTask "halon::rc::new-subscription" $
       _ <- monitor pid
       rawSubscribeThem self fp pid
     rc <- getCurrentRC
-    modifyGraph $ \g -> do
-      let s  = R.Subscriber pid bs
-          p  = R.SubProcessId pid
-      let g' = G.newResource s
-           >>> G.newResource p
-           >>> G.connect p R.IsSubscriber s
-           >>> G.connect s R.SubscribedTo rc
-             $ g
-      g'
+    let s  = R.Subscriber pid bs
+    modifyGraph $ G.connect (R.SubProcessId pid) R.IsSubscriber s
+              >>> G.connect s R.SubscribedTo rc
+
     registerSyncGraphCallback $ \_ _ -> do
       usend pid (SubscribeToReply bs)
 
@@ -128,8 +123,7 @@ ruleRemoveSubscription = defineSimpleTask "halon::rc::remove-subscription" $
     rc <- getCurrentRC
     modifyGraph $ \g -> do
       let s  = R.Subscriber pid bs
-          p  = R.SubProcessId pid
-      let g' = G.disconnect p R.IsSubscriber s
+          g' = G.disconnect (R.SubProcessId pid) R.IsSubscriber s
            >>> G.disconnect s R.SubscribedTo rc
              $ g
       g'

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Service/Actions.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Service/Actions.hs
@@ -73,7 +73,7 @@ findRegisteredOn node = go <$> getLocalGraph
 declare  :: Configuration a
          => Service a
          -> PhaseM RC l ()
-declare svc = modifyGraph $ G.newResource svc >>> G.connect Cluster Supports svc
+declare svc = modifyGraph $ G.connect Cluster Supports svc
 
 -- | Register service on a given node. After this halon will know that it needs
 -- to send information to regular monitor services.

--- a/mero-halon/src/lib/HA/Services/Mero/RC/Actions.hs
+++ b/mero-halon/src/lib/HA/Services/Mero/RC/Actions.hs
@@ -69,10 +69,7 @@ registerChannel :: ( Resource (TypedChannel a)
                 => R.Node
                 -> TypedChannel a
                 -> PhaseM RC l ()
-registerChannel sp chan =
-  modifyGraph $ G.newResource sp
-            >>> G.newResource chan
-            >>> G.connect sp MeroChannel chan
+registerChannel sp chan = modifyGraph $ G.connect sp MeroChannel chan
 
 -- | Unregister mero channel inside RG.
 unregisterChannel :: forall a l proxy .
@@ -151,9 +148,7 @@ mkStateDiff f msg onCommit = do
   let idx  = StateDiffIndex epoch
       diff = StateDiff epoch msg onCommit
   rc    <- getCurrentRC
-  modifyGraph $ G.newResource diff
-            >>> G.newResource idx
-            >>> G.connect idx R.Is diff
+  modifyGraph $ G.connect idx R.Is diff
             >>> G.connect rc R.Has diff
             >>> f
   return diff


### PR DESCRIPTION
*Created by: Fuuzetsu*

This function was pointless: it was always adding a dangling node,
adding to graph changelog and was always followed by `connect*` which
did the same thing. Only places that relied on "insert but don't
connect" behaviour were both in tests.

* in GC test, simply add a pair of connected nodes that aren't connected
  to the root set and use those for GC test

* in resource merge tests, we were trying to build links from a subset
  of resources already in the graph but we were no longer adding
  resources to the graph explicitly so in cases where number of
  relations was generated to be 0, QuickCheck would forever try to
  generate a test case; fix is to always have at least one relation