### PR TITLE
Remove spurious dependencies from halon-instances

### DIFF
--- a/halon-instances/halon-instances.cabal
+++ b/halon-instances/halon-instances.cabal
@@ -9,16 +9,6 @@ build-type:          Simple
 -- extra-source-files:
 cabal-version:       >=1.10
 
-Flag maintainer
-  Description: Enforce strict code quality checks (-Werror, etc)
-  Default: False
-
--- ghc-heap-view cannot be built with profiling, does we need to drop
--- ghc-datasize which depends on it.
-Flag profiling
-  Description: Drop dependencies which can't be built with profiling enabled.
-  Default: False
-
 library
   hs-source-dirs:      src
   exposed-modules:     HA.SafeCopy
@@ -33,7 +23,6 @@ library
                        cereal,
                        distributed-process,
                        distributed-process-scheduler,
-                       hashable,
                        network-transport,
                        options-schema,
                        safecopy,
@@ -44,8 +33,3 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
-
-  if !flag(profiling)
-    build-depends:     ghc-datasize
-  if flag(maintainer)
-    Ghc-Options: -Werror


### PR DESCRIPTION
*Created by: Fuuzetsu*

Notably, ghc-heap-view; copy-paste failure.