### PR TITLE
m0_init_wrapper(): don't check for version compatibility

### DIFF
--- a/rpclite/rpclite/m0init.c
+++ b/rpclite/rpclite/m0init.c
@@ -13,33 +13,10 @@
 struct m0_halon_interface* m0init_hi = NULL;
 
 int m0_init_wrapper () {
-    const struct m0_build_info* bi = m0_build_info_get();
-    int disable_compat_check = getenv("DISABLE_MERO_COMPAT_CHECK") == NULL;
-    if (0 != strcmp(bi->bi_git_rev_id, M0_VERSION_GIT_REV_ID)) {
-      fprintf(stderr, "m0_init_wrapper: The loaded mero library (%s) "
-                      "is not the expected one (%s)\n"
-                    , bi->bi_git_rev_id
-                    , M0_VERSION_GIT_REV_ID
-             );
-      if (disable_compat_check) {
-        exit(1);
-      }
-    }
-    if (0 != strcmp(bi->bi_configure_opts, M0_VERSION_BUILD_CONFIGURE_OPTS)) {
-      fprintf(stderr, "m0_init_wrapper: the configuration options of the "
-                      "loaded mero library (%s) do not match the expected ones "
-                      "(%s)\n"
-                    , bi->bi_configure_opts
-                    , M0_VERSION_BUILD_CONFIGURE_OPTS
-             );
-      if (disable_compat_check) {
-        exit(1);
-      }
-    }
     return m0_halon_interface_init( &m0init_hi
                                   , M0_VERSION_GIT_REV_ID
                                   , M0_VERSION_BUILD_CONFIGURE_OPTS
-                                  , disable_compat_check
+                                  , getenv("DISABLE_MERO_COMPAT_CHECK") != NULL
                                   , NULL);
 }
 


### PR DESCRIPTION
*Created by: mmedved*

m0_halon_interface_init() does this already.

After version upgrade feature is added to Mero the check in Halon would
make no sense (because only Mero can check if the versions of libmero.so
are compatible).