### PR TITLE
HALON-499: Disallow PSOffline -> PSFailed

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Transitions.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Transitions.hs
@@ -32,8 +32,10 @@ type CascadeTransition a b = StateCarrier a -> Transition b
 -- * 'M0.Process'
 
 -- | Fail a process with the given reason.
-processFailed :: String -> Transition M0.Process
-processFailed = constTransition . M0.PSFailed
+processFailed :: (?loc :: CallStack) => String -> Transition M0.Process
+processFailed m = Transition $ \case
+  st@M0.PSOffline -> transitionErr ?loc st
+  _ -> TransitionTo $ M0.PSFailed m
 
 -- | HA 'M0.Process' online.
 processHAOnline :: Transition M0.Process


### PR DESCRIPTION
*Created by: Fuuzetsu*

It can happen that:

* we request process stop
* we receive HA_PROCESS_STOPPED event from mero
* we set PSOffline (`ruleProcessStopped`) due to above
* process stop `systemctl` command fails somehow: for example,
  @halon:m0d@ service is stopped which results in exception propagated
  through `ProcessControlStopResult`
* PSFailed is set (`ruleProcessStop`) from PSOffline
* User experience is degraded (mysterious process failure when
  everything is actually OK)

There is basically a race between receiving HA_PROCESS_STOPPED and
receiving a conflicting `ProcessControlStopResult`. If the process
reported to be stopped, we trust that. Simply disallow the transition
out of PSOffline in this case.