### PR TITLE
Prototype implementation of unconstrained graph.

### DIFF
--- a/halon/src/lib/HA/ResourceGraph/GraphLike.hs
+++ b/halon/src/lib/HA/ResourceGraph/GraphLike.hs
@@ -1,0 +1,64 @@
+module HA.ResourceGraph.GraphLike where
+
+class GraphLike a where
+  type InsertableRes a :: * -> Constraint
+  type InsertableRel a :: * -> * -> * -> Constraint
+
+  type Resource a :: * -> Constraint
+  type Relation a :: * -> * -> * -> Constraint
+
+  type UniversalResource a :: *
+  type UniversalRelation a :: *
+
+  encodeUniversalResource :: UniversalResource
+                          -> ByteString
+  encodeUniversalRelation :: UniversalRelation
+                          -> ByteString
+  decodeUniversalResource :: RemoteTable
+                          -> ByteString
+                          -> UniversalResource
+  decodeUniversalRelation :: RemoteTable
+                          -> ByteString
+                          -> UniversalRelation
+
+  encodeIRes :: InsertableRes a => a -> UniversalResource
+  encodeIRelIn :: InsertableRel r a b => a -> r -> b -> UniversalRelation
+  encodeIRelOut :: InsertableRel r a b => a -> r -> b -> UniversalRelation
+
+  queryRes :: Resource a => a -> (UniversalResource -> Bool)
+  queryRel :: Relation r a b -> a -> r -> b -> (UniversalRelation -> Bool)
+
+  graph :: Lens' a (HashMap UniversalResource (HashSet UniversalRelation))
+
+  storeChan :: Lens' a StoreChan
+
+  changeLog :: Lens' a ChangeLog
+
+memberResource :: (GraphLike g, Resource g a) => a -> g -> Bool
+memberResource a g = isJust . find (queryRes a) $ M.keys $ g ^. graph
+
+-- | Adds a relation without making a conversion from 'Edge'.
+--
+-- Unlike 'connect', it doesn't check cardinalities.
+connectUnbounded :: ( GraphLike g
+                    , InsertableRes g a
+                    , InsertableRes g b
+                    , InsertableRel g r a b
+                    )
+                 => a -> r -> b -> g -> g
+connectUnbounded x r y g =
+    over changeLog
+      (updateChangeLog $
+         InsertMany [ (eRes x),[ eRelO r x y ])
+                    , (eRes y),[ eRelI r x y ])
+                    ]
+      )
+    . over graph
+        ( M.insertWith S.union (encodeIRes x) (S.singleton $ encodeIRelOut r x y)
+        . M.insertWith S.union (encodeIRes y) (S.singleton $ encodeIRelIn r x y)
+        )
+    $ g
+  where
+    eRes = encodeUniversalResource . encodeIRes
+    eRelI = encodeUniversalRelation . encodeIRelIn
+    eRelO = encodeUniversalRelation . encodeIRelOut

--- a/halon/src/lib/HA/ResourceGraph/Unconstrained.hs
+++ b/halon/src/lib/HA/ResourceGraph/Unconstrained.hs
@@ -1,0 +1,45 @@
+module HA.ResourceGraph.Unconstrained where
+
+import HA.ResourceGraph (Resource, Relation)
+import qualified HA.ResourceGraph.GraphLike as GL
+
+type family Unconstrained (a :: *) :: Constraint where
+  Unconstrained a = ()
+
+data Res = forall a. (Static a, ByteString)
+data Rel = forall a. (Static a, Word8, ByteString, ByteString, ByteString)
+
+data UGraph = Graph
+  { -- | Channel used to communicate with the multimap which replicates the
+    -- graph.
+    _grMMChan :: StoreChan
+    -- | Changes in the graph with respect to the version stored in the multimap.
+  , _grChangeLog :: !ChangeLog
+    -- | The graph.
+  , _grGraph :: HashMap Res (HashSet Rel)
+  } deriving (Typeable)
+makeLenses ''UGraph
+
+instance GL.GraphLike UGraph where
+  type GL.InsertableRes UGraph = Resource
+  type GL.InsertableRel UGraph = Relation
+
+  type GL.Resource UGraph = SafeCopy
+  type GL.Relation UGraph r a b = SafeCopy r
+
+  type GL.UniversalResource UGraph = Res
+  type GL.UniversalRelation UGraph = Rel
+
+  encodeUniversalResource (x, y) = toStrict $ encode x `append` y
+  
+  encodeIRes r = ( $(mkStatic 'someResourceDict) `staticApply`
+                     (resourceDict :: Static (Dict (Resource r)))
+                  , safePut r)
+
+  queryRes r = (\x -> snd x == safePut r)
+
+  graph = grGraph
+
+  changelog = grChangeLog
+
+  storeChan = grMMChan


### PR DESCRIPTION
*Created by: nc6*

Some sample functions are implemented, but this doesn't compile.
For discussion only!

[skip ci]

Sketch of an implementation for unconstrained graph. Basic principle is:
- Anything which inserts a resource/relation requires an extra constraint basically equivalent to usual RG constraints, thus ensuring that stuff we add in will work in the new version.
- Otherwise, looking up existing things requires only a way to *query* for existing resources. This is equivalent to having `SafeCopy` instances around. No static evidence is needed for these.
- Removing existing resources is done by re-using the encoded representation already present, thus we don’t need to provide any evidence, since the encoded representation is the bytestring one.

So principle would be, when upgrading, if we just keep around `SafeCopy` instances, we can throw away everything else but continue to manipulate the graph with them in, without having to deal directly with `ByteString` representation

The main downside I see if that lookups become implemented using (slow) filter semantics rather than `member`. We could work around this by adding the "find" function to the class and overriding it.