### PR TITLE
Fix require-mero test runner

### DIFF
--- a/mero-halon/tests/HA/RecoveryCoordinator/Helpers.hs
+++ b/mero-halon/tests/HA/RecoveryCoordinator/Helpers.hs
@@ -30,11 +30,9 @@ import HA.Services.SSPL.Rabbit
 import Network.CEP (Published(..))
 import Network.Transport (Transport(..))
 import RemoteTables (remoteTable)
-import System.Directory (getCurrentDirectory)
 import Test.Framework (TestTree, withTmpDirectory)
 import Test.Tasty.HUnit (testCase)
 import TestRunner
-import Text.Printf (printf)
 
 -- | Run the test with some common test parameters
 runDefaultTest :: Transport -> Process () -> IO ()
@@ -42,10 +40,8 @@ runDefaultTest transport act = runTest 1 20 15000000 transport testRemoteTable $
 
 -- | Tag a test with @[require-mero]@ and run it inside a temporary
 -- directory.
-testMero :: String -> IO () -> IO TestTree
-testMero n act = withTmpDirectory $ do
-  dir <- getCurrentDirectory
-  return $ testCase (printf "[require-mero] %s (%s)" n dir) act
+testMero :: String -> IO () -> TestTree
+testMero n = testCase ("[require-mero] " ++ n) . withTmpDirectory
 
 testRemoteTable :: RemoteTable
 testRemoteTable = TestRunner.__remoteTableDecl remoteTable

--- a/mero-halon/tests/HA/RecoveryCoordinator/Mero/Tests.hs
+++ b/mero-halon/tests/HA/RecoveryCoordinator/Mero/Tests.hs
@@ -47,17 +47,13 @@ import           Test.Framework
 import           Test.Tasty.HUnit (assertEqual, assertBool, testCase)
 import           TestRunner
 
-tests ::  (Typeable g, RGroup g) => Transport -> Proxy g -> IO [TestTree]
-tests transport pg = do
-  goodConfLoads <- testMero "good-conf-loads" $ testGoodConfLoads transport pg
-  badConfDoesNotLoad <- testMero "bad-conf-does-not-load" $
-    testBadConfDoesNotLoad transport pg
-  return
-    [ testCase "testDriveManagerUpdate" $ testDriveManagerUpdate transport pg
-    , testCase "testConfObjectStateQuery" $ testConfObjectStateQuery transport pg
-    , goodConfLoads
-    , badConfDoesNotLoad
-    ]
+tests ::  (Typeable g, RGroup g) => Transport -> Proxy g -> [TestTree]
+tests transport pg =
+  [ testCase "testDriveManagerUpdate" $ testDriveManagerUpdate transport pg
+  , testCase "testConfObjectStateQuery" $ testConfObjectStateQuery transport pg
+  , testMero "good-conf-loads" $ testGoodConfLoads transport pg
+  , testMero "bad-conf-does-not-load" $ testBadConfDoesNotLoad transport pg
+  ]
 
 -- | Used by 'testDriveManagerUpdate'
 newtype RunDriveManagerFailure = RunDriveManagerFailure StorageDevice

--- a/mero-halon/tests/tests.hs
+++ b/mero-halon/tests/tests.hs
@@ -40,7 +40,6 @@ tests transport breakConnection = do
   driveFailureTests <- HA.Castor.Story.Tests.mkTests pg
   processTests <- HA.Castor.Story.Process.mkTests pg
   internalSCTests <- HA.Test.InternalStateChanges.mkTests pg
-  meroTests <- HA.RecoveryCoordinator.Mero.Tests.tests transport pg
   return $ testGroup "mero-halon:tests"
       [ testGroup "RC" $ HA.RecoveryCoordinator.Tests.tests transport pg
       , testGroup "Autoboot" $ HA.Autoboot.Tests.tests transport
@@ -48,7 +47,7 @@ tests transport breakConnection = do
       , testGroup "Castor" $ HA.Castor.Tests.tests transport pg
       , testGroup "DriveFailure" $ driveFailureTests transport
       , testGroup "InternalStateChanges" $ internalSCTests transport
-      , testGroup "Mero" meroTests
+      , testGroup "Mero" $ HA.RecoveryCoordinator.Mero.Tests.tests transport pg
       , testGroup "NotificationSort" HA.Test.NotificationSort.tests
       , testGroup "Process" $ processTests transport
       , testGroup "Service-SSPL" $ HA.RecoveryCoordinator.SSPL.Tests.utTests transport pg


### PR DESCRIPTION
*Created by: Fuuzetsu*

Problem was that withTmpDirectory is left before test runner writes the result so it tries to write into a bad location.

With this we should get the test result into a predictable place like the others.

It should turn castor green.