### PR TITLE
HALON-625: Ensure repaired/rebalancing persists through reset

### DIFF
--- a/mero-halon/doc/diagrams/sdev-state-transitions.dot
+++ b/mero-halon/doc/diagrams/sdev-state-transitions.dot
@@ -29,7 +29,11 @@ digraph {
     edge[label="rebalance complete"];
     rebalance -> online;
     edge[label="rebalance abort/\npartial rebalance"];
-    rebalance->repaired;
+    rebalance -> repaired;
+    edge[label="disk reset"];
+    repaired -> repaired;
     edge[label="failure detection/\ndrive removed"];
     rebalance -> transient;
+    edge[label="disk reset"];
+    rebalance -> rebalance;
 }

--- a/mero-halon/src/lib/HA/Resources/Mero.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero.hs
@@ -400,6 +400,7 @@ sdsFailTransient :: SDevState -> SDevState
 sdsFailTransient SDSFailed = SDSFailed
 sdsFailTransient SDSRepairing = SDSRepairing
 sdsFailTransient SDSRepaired = SDSRepaired
+sdsFailTransient SDSRebalancing = SDSRebalancing
 sdsFailTransient s@(SDSTransient _) = s
 sdsFailTransient (SDSInhibited x) = SDSInhibited $ sdsFailTransient x
 sdsFailTransient x = SDSTransient x

--- a/mero-halon/tests/Helper/Runner.hs
+++ b/mero-halon/tests/Helper/Runner.hs
@@ -13,6 +13,7 @@
 -- tests.
 module Helper.Runner
   ( ClusterSetup(..)
+  , RuleHook(..)
   , TestOptions(..)
   , TestSetup(..)
   , mkDefaultTestOptions
@@ -146,6 +147,11 @@ data PopulateMockReply = MockRunning NodeId
   deriving (Show, Eq, Ord, Generic, Typeable)
 instance Binary PopulateMockReply
 
+-- | Used to fire internal test rules. Many tests define a single rule
+-- that they want to fire and reply from: this provides a common type
+-- for that.
+newtype RuleHook = RuleHook ProcessId
+  deriving (Generic, Typeable, Binary)
 
 testRules :: Definitions RC ()
 testRules = do


### PR DESCRIPTION
*Created by: Fuuzetsu*

The assumption here is that repaired/rebalancing states are already
considered failed states so we don't have to do extra book-keeping.

Personally I don't really like how it's done. This approach was taken
w.r.t. repaired state in HALON-417 initially but without very good
motivation except that it unblocks a test.