### PR TITLE
HALON-635: Use only correct configure result

### DIFF
--- a/mero-halon/tests/HA/Services/Mero/Mock.hs
+++ b/mero-halon/tests/HA/Services/Mero/Mock.hs
@@ -343,9 +343,9 @@ controlProcess conf master pcChan = do
   link master
   nid <- getSelfNode
   forever $ receiveChan pcChan >>= \case
-    ConfigureProcess runType pconf mkfs ->
+    ConfigureProcess runType pconf mkfs uid ->
       configureProcess runType pconf mkfs >>=
-        promulgateWait . ProcessControlResultConfigureMsg nid
+        promulgateWait . ProcessControlResultConfigureMsg nid uid
     StartProcess runType p -> startProcess runType p >>=
       promulgateWait . ProcessControlResultMsg nid
     StopProcess runType p -> stopProcess runType p >>=


### PR DESCRIPTION
*Created by: Fuuzetsu*

This stops scenario as follows:

* ruleProcessStart
* configureProcess sent out
* mkfs runs and completes soon after
* RC restarts
* ruleProcessStart restarts
* configureProcess sent out
* mkfs runs
* the initial configureProcess reply handled
* startProcess sent out
* we have mkfs and m0d running at the same time