### PR TITLE
HALON-667: Display correct names in cluster status.

### DIFF
--- a/mero-halon/src/halonctl/Handler/Cluster.hs
+++ b/mero-halon/src/halonctl/Handler/Cluster.hs
@@ -45,7 +45,7 @@ import HA.RecoveryCoordinator.RC.Events
 import HA.RecoveryCoordinator.RC.Events.Cluster
 import HA.RecoveryCoordinator.Mero.Events
 import HA.RecoveryCoordinator.Mero (labelRecoveryCoordinator)
-import Mero.ConfC (ServiceType(..), fidToStr, strToFid)
+import Mero.ConfC (fidToStr, strToFid)
 import Mero.Spiel (FSStats(..))
 import Network.CEP
 import System.Exit (exitFailure, exitSuccess)
@@ -129,7 +129,7 @@ parseDriveCommand = CastorDriveCommand <$> asum
    where
      parseDriveNew :: Parser DriveCommand
      parseDriveNew = DriveNew <$> optSerial <*> optPath
-                                           
+
      parseDrivePresence :: Parser DriveCommand
      parseDrivePresence = DrivePresence
         <$> optSerial
@@ -783,12 +783,13 @@ prettyReport showDevices (ReportClusterState status sns info' mstats hosts) = do
          let (nst,extSt) = M0.displayNodeState st
          printf node_pattern nst (showNodeFid m0fid) qfdn
          for_ extSt $ printf node_pattern_ext (""::String)
-         forM_ ps $ \(M0.Process{r_fid=rfid, r_endpoint=endpoint}, ReportClusterProcess proc_st srvs) -> do
+         forM_ ps $ \( M0.Process{r_fid=rfid, r_endpoint=endpoint}
+                     , ReportClusterProcess ptype proc_st srvs) -> do
            let (pst,proc_extSt) = M0.displayProcessState proc_st
            printf proc_pattern pst
                                (fidToStr rfid)
                                endpoint
-                               (inferType (map crsService srvs)::String)
+                               ptype
            for_ proc_extSt $ printf proc_pattern_ext (""::String)
            for_ srvs $ \(ReportClusterService sst (M0.Service fid' t' _ _) sdevs) -> do
              let (serv_st,serv_extSt) = M0.displayServiceState sst
@@ -807,12 +808,6 @@ prettyReport showDevices (ReportClusterState status sns info' mstats hosts) = do
                  for_ sdev_extSt $ printf sdev_pattern_ext (""::String)
                  for_ mslot $ printf sdev_patterni (""::String) . show
    where
-     inferType srvs
-       | any (\(M0.Service _ t _ _) -> t == CST_IOS) srvs = "ioservice"
-       | any (\(M0.Service _ t _ _) -> t == CST_MDS) srvs = "mdservice"
-       | any (\(M0.Service _ t _ _) -> t == CST_MGS) srvs = "confd    "
-       | any (\(M0.Service _ t _ _) -> t == CST_HA)  srvs = "halon    "
-       | otherwise                                        = "m0t1fs   "
      showNodeFid Nothing = ""
      showNodeFid (Just (M0.Node fid)) = show fid
      node_pattern  = "  [%9s] %-24s  %s\n"

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Events.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Events.hs
@@ -183,7 +183,9 @@ instance FromJSON ReportClusterHost
 
 -- | Information about a 'M0.Process'.
 data ReportClusterProcess = ReportClusterProcess
-      { crpState    :: M0.ProcessState
+      { cprType :: String
+      -- ^ 'Type' of the process, such as ios, m0t1fs etc
+      , crpState    :: M0.ProcessState
       -- ^ 'M0.ProcessState' of the 'M0.Process'.
       , crpServices :: [ReportClusterService]
       -- ^ 'M0.Service's and their states associated with this
@@ -199,7 +201,7 @@ data ReportClusterService = ReportClusterService
       { crsState      :: M0.ServiceState
       -- ^ 'M0.ServiceState' of the 'M0.Service'
       , crsService    :: M0.Service
-      -- ^ 'M0.Service' 
+      -- ^ 'M0.Service'
       , crsDevices    :: [( M0.SDev
                           , M0.StateCarrier M0.SDev
                           , Maybe Castor.Slot

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Rules.hs
@@ -195,7 +195,9 @@ requestClusterStatus = defineSimpleTask "castor::cluster::request::status"
                      processes <- getChildren node
                      forM processes $ \process -> do
                        let st = M0.getState process rg
+                           mpl = G.connectedTo process R.Has rg
                        services  <- sort <$> getChildren process
+                       let ptyp = getType mpl services
                        services' <- forM services $ \service -> do
                           sdevs  <- sort <$> getChildren service
                           sdevs' <- forM sdevs $ \sdev -> do
@@ -206,7 +208,7 @@ requestClusterStatus = defineSimpleTask "castor::cluster::request::status"
                                 state = M0.getState sdev rg
                             return (sdev, state, slot, msd)
                           return (ReportClusterService (M0.getState service rg) service sdevs')
-                       return (process, ReportClusterProcess st services')
+                       return (process, ReportClusterProcess ptyp st services')
             return (host, ReportClusterHost (listToMaybe nodes) node_st (sort $ join prs))
       liftProcess . sendChan ch $ ReportClusterState
         { csrStatus = status
@@ -215,6 +217,16 @@ requestClusterStatus = defineSimpleTask "castor::cluster::request::status"
         , csrStats  = stats
         , csrHosts  = hosts
         }
+  where
+    getType (Just M0.PLM0t1fs) _ = "m0t1fs"
+    getType (Just (M0.PLClovis s _)) _ = s
+    getType (Just M0.PLHalon) _ = "halon"
+    getType _ srvs = inferType srvs
+    inferType srvs
+      | any (\(M0.Service _ t _ _) -> t == CST_IOS) srvs = "ioservice"
+      | any (\(M0.Service _ t _ _) -> t == CST_MDS) srvs = "mdservice"
+      | any (\(M0.Service _ t _ _) -> t == CST_MGS) srvs = "confd    "
+      | otherwise                                        = "m0d      "
 
 jobClusterStart :: Job ClusterStartRequest ClusterStartResult
 jobClusterStart = Job "castor::cluster::start"


### PR DESCRIPTION
*Created by: nc6*

This is particularly an issue for clovis processes, which
may have different names specified in the configuration.