### PR TITLE
HALON-678: Use applyStateChanges notifications

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Actions/Mero.hs
@@ -347,7 +347,7 @@ startMeroService host node = do
                                  (MeroKernelConf uuid)
       in (encodeP $ ServiceStartRequest Start node (lookupM0d rg) conf [], p)
   for_ minfo $ \(msg, p) -> do
-    applyStateChanges [ stateSet p Tr.processStarting ]
+    _ <- applyStateChanges [ stateSet p Tr.processStarting ]
     promulgateRC msg
 
 -- | It may happen that a node reboots (either through halon or

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/CEP.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/CEP.hs
@@ -255,7 +255,7 @@ ruleRecoverNode argv = mkJobRule recoverJob args $ \(JobHandle _ finish) -> do
                 -- back before recovery fired? unlikely but who knows
                 case nodeToM0Node n1 g of
                   Nothing -> RCLog.rcLog' RCLog.WARN ("Couldn't find mero node." :: String)
-                  Just n -> applyStateChanges [stateSet n nodeFailed]
+                  Just n -> void $ applyStateChanges [stateSet n nodeFailed]
                 -- if the node is a mero server then power-cycle it.
                 -- Client nodes can run client-software that may not be
                 -- OK with reboots so we only reboot servers.

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Service/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Service/Rules.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE DataKinds  #-}
+{-# LANGUAGE LambdaCase #-}
 -- |
 -- Module    : HA.RecoveryCoordinator.Castor.Service.Rules
--- Copyright : (C) 2016 Seagate Technology Limited.
+-- Copyright : (C) 2016-2017 Seagate Technology Limited.
 -- License   : All rights reserved.
 --
 -- Service related rules.
@@ -9,43 +10,31 @@ module HA.RecoveryCoordinator.Castor.Service.Rules
   ( rules
   ) where
 
-import HA.EventQueue (HAEvent(..))
-import HA.RecoveryCoordinator.RC.Actions
-  ( RC
-  , LoopState(..)
-  , todo
-  , done
-  , getLocalGraph
-  )
-import HA.RecoveryCoordinator.Mero.Events (stateSet)
-import qualified HA.RecoveryCoordinator.RC.Actions.Log as Log
-import HA.RecoveryCoordinator.Mero.Notifications (setPhaseNotified)
-import HA.RecoveryCoordinator.Mero.State (applyStateChanges)
+import           Control.Lens
+import           Control.Monad (void)
+import           Data.Foldable (for_)
+import           Data.Maybe (fromMaybe)
+import           Data.Proxy
+import           Data.Vinyl
+import           HA.EventQueue (HAEvent(..))
+import           HA.RecoveryCoordinator.Mero.Events (stateSet)
+import           HA.RecoveryCoordinator.Mero.Notifications
+import           HA.RecoveryCoordinator.Mero.State (applyStateChanges)
 import qualified HA.RecoveryCoordinator.Mero.Transitions as Tr
+import           HA.RecoveryCoordinator.RC.Actions
+import qualified HA.RecoveryCoordinator.RC.Actions.Log as Log
 import qualified HA.ResourceGraph as G
+import qualified HA.Resources as R
 import qualified HA.Resources.Mero as M0
 import qualified HA.Resources.Mero.Note as M0
-import qualified HA.Resources as R
-import Mero.ConfC (ServiceType(..))
-import Mero.Notification.HAState
+import           Mero.ConfC (ServiceType(..))
+import           Mero.Notification.HAState
   ( HAMsg(..)
   , HAMsgMeta(..)
   , ServiceEvent(..)
   , ServiceEventType(..)
   )
-
-import Data.Foldable (for_)
-import Data.Maybe (fromMaybe)
-import Data.UUID (UUID)
-
-import Network.CEP
-
--- | Local state used in 'ruleServiceNotificationHandler'.
-type ClusterTransitionLocal =
-  Maybe ( UUID
-        , Maybe (M0.Service, M0.ServiceState)
-        , Maybe (M0.Process, M0.ProcessState)
-        )
+import           Network.CEP
 
 -- | Handle notification for service states. This rule is responsible
 -- for logic that sets service states, decides what to do with the
@@ -57,23 +46,19 @@ ruleNotificationHandler = define "castor::service::notification-handler" $ do
   service_notified <- phaseHandle "service-notified"
   timed_out <- phaseHandle "timed-out"
   finish <- phaseHandle "finish"
-
-  let startState :: ClusterTransitionLocal
-      startState = Nothing
-
-      viewSrv :: ClusterTransitionLocal -> Maybe (M0.Service, M0.ServiceState -> Bool)
-      viewSrv = maybe Nothing (\(_,srvi,_) -> fmap (fmap (==)) srvi)
+  dispatcher <- mkDispatcher
+  notifier <- mkNotifierSimple dispatcher
 
       -- Check that the service has the given tag (predicate) and
       -- check that it's not in the given state in RG already.
-      serviceTagged p typ (HAEvent eid (HAMsg (ServiceEvent se st _pid) m)) ls =
+  let serviceTagged p typ (HAEvent eid (HAMsg (ServiceEvent se st _pid) m)) ls =
         let rg = lsGraph ls
             isStateChanged s = M0.getState s (lsGraph ls) /= typ
         in case M0.lookupConfObjByFid (_hm_fid m) rg of
             Just (s :: M0.Service) | p se && isStateChanged s -> Just (eid, s, typ, st)
             _ -> Nothing
 
-      servicePidMatches (HAEvent _ (HAMsg (ServiceEvent _ _ spid) m)) ls =
+      servicePidMatches (HAMsg (ServiceEvent _ _ spid) m) ls =
         let rg = lsGraph ls
             msd = M0.lookupConfObjByFid (_hm_fid m) (lsGraph ls) :: Maybe M0.Service
         in case msd of
@@ -92,57 +77,60 @@ ruleNotificationHandler = define "castor::service::notification-handler" $ do
       isServiceOnline = serviceTagged (== TAG_M0_CONF_HA_SERVICE_STARTED) M0.SSOnline
       isServiceStopped = serviceTagged (== TAG_M0_CONF_HA_SERVICE_STOPPED) M0.SSOffline
 
-      startOrStop msg@(HAEvent eid _) ls _ = return . Just . maybe (Left eid) Right $
-        if servicePidMatches msg ls
+      startOrStop msg@(HAEvent _ v) ls _ = return $
+        if servicePidMatches v ls
         then case isServiceOnline msg ls of
                Nothing -> isServiceStopped msg ls
                Just x -> Just x
         else Nothing
 
-  setPhaseIf start_rule startOrStop $ \case
-    Left eid -> todo eid >> done eid -- XXX: just remove this guy?
-    Right (eid, service, st, typ) -> do
-      todo eid
-      Log.tagContext Log.SM service Nothing
-      phaseLog "begin" "Service transition"
-      Log.tagContext Log.SM [
-          ("transaction.id", show eid)
-        , ("service.state", show st)
-        , ("service.type", show typ)
-        ] Nothing
-      rg <- getLocalGraph
-      let haSiblings =
-            [ svc | Just (p :: M0.Process) <- [G.connectedFrom M0.IsParentOf service rg]
-                  , svc <- G.connectedTo p M0.IsParentOf rg
-                  , M0.s_type svc == CST_HA ]
-      case haSiblings of
-        -- This service is not process-co-located with any CST_HA
-        -- service
-        [] -> do
-          put Local $ Just (eid, Just (service, st), Nothing)
-          let tr = if st == M0.SSOnline then Tr.serviceOnline else Tr.serviceOffline
-          applyStateChanges [stateSet service tr]
-          switch [service_notified, timeout 30 timed_out]
-        -- We're working with services for halon process: ignore these
-        -- service message as
-        --
-        -- - we can't tell if the message is current
-        --
-        -- - without abnormal scenario, PROCESS_STOPPED will always be
-        --   sent for this process too
-        --
-        -- - we don't want to fight with PROCESS_STOPPED for no reason
-        --   and be subject to poor ordering
-        _ -> phaseLog "warn" "Ignoring mero notification about a halon:m0d process service."
+  setPhaseIfConsume start_rule startOrStop $ \(eid, service, st, typ) -> do
+    todo eid
+    Log.tagContext Log.SM service Nothing
+    Log.tagContext Log.SM [
+        ("transaction.id", show eid)
+      , ("service.state", show st)
+      , ("service.type", show typ)
+      ] Nothing
+    rg <- getLocalGraph
+    let haSiblings =
+          [ svc | Just (p :: M0.Process) <- [G.connectedFrom M0.IsParentOf service rg]
+                , svc <- G.connectedTo p M0.IsParentOf rg
+                , M0.s_type svc == CST_HA ]
+    case haSiblings of
+      -- This service is not process-co-located with any CST_HA
+      -- service
+      [] -> do
+        modify Local $ rlens fldUUID . rfield .~ Just eid
+        modify Local $ rlens fldService . rfield .~ Just service
+        modify Local $ rlens fldServiceState . rfield .~ Just st
+        let tr = if st == M0.SSOnline then Tr.serviceOnline else Tr.serviceOffline
+        notifications <- applyStateChanges [stateSet service tr]
+        setExpectedNotifications notifications
+        onTimeout 30 timed_out
+        onSuccess service_notified
+        waitFor notifier
+        continue dispatcher
+      -- We're working with services for halon process: ignore these
+      -- service messages as
+      --
+      -- - we can't tell if the message is current
+      --
+      -- - without abnormal scenario, PROCESS_STOPPED will always be
+      --   sent for this process too
+      --
+      -- - we don't want to fight with PROCESS_STOPPED for no reason
+      --   and be subject to poor ordering
+      _ -> Log.rcLog' Log.WARN "Ignoring mero notification about a halon:m0d process service."
 
-  setPhaseNotified service_notified viewSrv $ \(srv, st) -> do
+  directly service_notified $ do
+    Just srv <- getField . rget fldService <$> get Local
+    Just st <- getField . rget fldServiceState <$> get Local
     rg <- getLocalGraph
     let mproc = G.connectedFrom M0.IsParentOf srv rg :: Maybe M0.Process
-    Just (eid, _, _) <- get Local
     Log.withLocalContext' $ do
-      for_ mproc $ \proc ->
-        Log.tagLocalContext proc $ Just "Process hosting service"
-      Log.rcLog Log.DEBUG ("transaction.id", show eid)
+      for_ mproc $ \p ->
+        Log.tagLocalContext p $ Just "Process hosting service"
       case (st, mproc) of
         (M0.SSOnline, Just p) -> case M0.getState p rg of
           M0.PSStopping -> do
@@ -160,24 +148,29 @@ ruleNotificationHandler = define "castor::service::notification-handler" $ do
           pst -> do
             Log.rcLog Log.DEBUG $ "Service for process failed, process state was " ++ show pst
             let failMsg = "Underlying service failed: " ++ show (M0.fid srv)
-            applyStateChanges [stateSet p $ Tr.processFailed failMsg]
+            void $ applyStateChanges [stateSet p $ Tr.processFailed failMsg]
         err ->
-          phaseLog "warn" $ "Couldn't handle bad state for " ++ M0.showFid srv
-                          ++ ": " ++ show err
+          Log.rcLog Log.WARN $ concat [ "Couldn't handle bad state for "
+                                      , M0.showFid srv, ": ", show err ]
     continue finish
 
   directly timed_out $ do
-    phaseLog "warn" $ "Waited too long for a notification ack"
+    Log.rcLog' Log.WARN "Waited too long for a notification ack"
     continue finish
 
-  directly finish $ get Local >>= \case
-    Just (eid, _, _) -> do
-      done eid
-      phaseLog "info" $ "transaction.idg = " ++ show eid
-      phaseLog "end" "Service transition."
-    lst -> phaseLog "warn" $ "In finish with strange local state: " ++ show lst
+  directly finish $ do
+    Just eid <- getField . rget fldUUID <$> get Local
+    done eid
 
-  startFork start_rule startState
+  startFork start_rule args
+  where
+    fldService = Proxy :: Proxy '("service", Maybe M0.Service)
+    fldServiceState = Proxy :: Proxy '("service-state", Maybe M0.ServiceState)
+    args = fldNotifications =: []
+       <+> fldDispatch =: Dispatch [] (error "ruleNotificationHandler.fldDispatch") Nothing
+       <+> fldService =: Nothing
+       <+> fldServiceState =: Nothing
+       <+> fldUUID =: Nothing
 
 -- | Service rules.
 rules :: Definitions RC ()

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Events.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Events.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE StandaloneDeriving        #-}
 {-# LANGUAGE TemplateHaskell           #-}
 {-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE TypeOperators             #-}
 {-# LANGUAGE ViewPatterns              #-}
 -- |
 -- Module    : HA.RecoveryCoordinator.Mero.Events
@@ -137,6 +138,12 @@ data AnyStateChange =
   deriving (Typeable)
 
 deriving instance Show AnyStateChange
+
+instance Eq AnyStateChange where
+  AnyStateChange (a :: a) oa na _ == AnyStateChange (b :: b) ob nb _ =
+    case eqT of
+      Just (Refl :: a :~: b) -> a == b && oa == ob && na == nb
+      _ -> False
 
 -- | Event sent when the state of an object changes internally to Halon.
 --   This event should be sent *after* the state of the references objects

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Rules/Maintenance.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Rules/Maintenance.hs
@@ -50,5 +50,5 @@ ruleUpdateObjectState = defineSimpleTask "mero::maintenance::update-object-state
                [(st, _)] -> do tell [stateSet o $ constTransition st]
                                return Success
                _ -> return ParseFailed
-     applyStateChanges updates
+     _ <- applyStateChanges updates
      liftProcess $ sendChan chan $ ForceObjectStateUpdateReply results

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/State.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/State.hs
@@ -167,11 +167,14 @@ createDeferredStateChanges stateSets rg =
         io' = x : io
 
 -- | Apply a number of state changes.
-applyStateChanges :: [AnyStateSet] -> PhaseM RC l ()
+applyStateChanges :: [AnyStateSet] -> PhaseM RC l [AnyStateChange]
 applyStateChanges ass = getLocalGraph >>= \rg -> do
   let (warns, changes) = createDeferredStateChanges ass rg
   for_ warns $ phaseLog "warn"
   applyDeferredStateChanges changes
+  let DeferredStateChanges _ _ (InternalObjectStateChange i) = changes
+  return i
+
 
 -- | Apply deferred state changes in the standard order.
 applyDeferredStateChanges :: DeferredStateChanges -> PhaseM RC l ()

--- a/mero-halon/src/lib/HA/Services/SSPL/CEP.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/CEP.hs
@@ -358,7 +358,7 @@ ruleMonitorServiceFailed = defineSimpleIf "monitor-service-failure" extract $ \(
             phaseLog "info" $ "Failing " ++ showFid p
             when updatePid $ do
               modifyLocalGraph $ return . connect p Has (M0.PID currentPid)
-            applyStateChanges [stateSet p $ processFailed "SSPL notification about service failure"]
+            void $ applyStateChanges [stateSet p $ processFailed "SSPL notification about service failure"]
       case listToMaybe $ filter (\p -> M0.r_fid p == processFid) svs of
         Nothing -> phaseLog "warn" $ "Couldn't find process with fid " ++ show processFid
         Just p -> do

--- a/mero-halon/tests/HA/Castor/Story/Tests.hs
+++ b/mero-halon/tests/HA/Castor/Story/Tests.hs
@@ -547,7 +547,7 @@ mkTestAroundReset transport pg devSt = run transport pg [setupRule] $ \ts -> do
         case msdev of
           Nothing -> liftProcess $ usend caller (Nothing :: Maybe M0.SDev)
           Just sdev -> do
-            applyStateChanges [ stateSet sdev $ TrI.constTransition devSt ]
+            _ <- applyStateChanges [ stateSet sdev $ TrI.constTransition devSt ]
             liftProcess . usend caller $ Just sdev
 
       start rule_init ()

--- a/mero-halon/tests/HA/RecoveryCoordinator/Mero/Tests.hs
+++ b/mero-halon/tests/HA/RecoveryCoordinator/Mero/Tests.hs
@@ -170,7 +170,7 @@ testConfObjectStateQuery transport pg = do
       setPhase init_state $ \(WaitFailedSDev caller m0sdev st) -> do
         let state = M0.sdsFailTransient st
         put Local (caller, m0sdev, state)
-        applyStateChanges [ stateSet m0sdev Tr.sdevFailTransient ]
+        _ <- applyStateChanges [ stateSet m0sdev Tr.sdevFailTransient ]
         continue wait_failure
 
       setPhaseNotified wait_failure (\(_, m0sdev, st) -> Just (m0sdev, (== st))) $ \(d, st) -> do

--- a/mero-halon/tests/HA/Test/InternalStateChanges.hs
+++ b/mero-halon/tests/HA/Test/InternalStateChanges.hs
@@ -85,7 +85,7 @@ stateCascade t pg = do
               , (proc :: M0.Process) <- G.connectedTo node M0.IsParentOf rg
               ]
           srvs = G.connectedTo p M0.IsParentOf rg :: [M0.Service]
-      applyStateChanges [stateSet p Tr.processStarting]
+      _ <- applyStateChanges [stateSet p Tr.processStarting]
       rg' <- getLocalGraph
 
       let allOK = getState p rg'  == M0.PSStarting
@@ -117,7 +117,7 @@ failvecCascade t pg = do
               , (disk :: M0.Disk) <- G.connectedTo controller M0.IsParentOf rg
               ]
           disks = [d0, d1]
-      applyStateChanges $ map (`stateSet` Tr.diskFailed) disks
+      _ <- applyStateChanges $ map (`stateSet` Tr.diskFailed) disks
       rg' <- getLocalGraph
 
       let pools =


### PR DESCRIPTION
*Created by: Fuuzetsu*

This removes the class of bug where the set of notifications we pass to
applyStateChanges and then wait for to be delivered is different than
the set of notifications that applyStateChanges actually ends up
creating. This caused bugs like CASTOR-2396 and more.