### PR TITLE
HALON-664: Remove unnecessary SafeCopy extensions

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Node/Events.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Node/Events.hs
@@ -90,31 +90,15 @@ data StartProcessesOnNodeResult =
 instance Binary StartProcessesOnNodeResult
 
 -- | Stop mero client process request.
-newtype StopMeroClientRequest_v0 =
-  StopMeroClientRequest_v0 Fid
-  -- ^ @StopMeroClientRequest clientProcessFid@
-  deriving (Eq, Show, Generic)
-
--- | Stop mero client process request.
 data StopMeroClientRequest =
   StopMeroClientRequest Fid String
   -- ^ @StopMeroClientRequest clientProcessFid reason@
   deriving (Eq, Show, Generic)
 
-instance Migrate StopMeroClientRequest where
-  type MigrateFrom StopMeroClientRequest = StopMeroClientRequest_v0
-  migrate (StopMeroClientRequest_v0 fid) = StopMeroClientRequest fid "unspecified"
-
 -- | Start mero client process request.
 newtype StartMeroClientRequest =
   StartMeroClientRequest Fid
   -- ^ @StartMeroClientRequest clientProcessFid@
-  deriving (Eq, Show, Generic)
-
--- | Legacy version of 'StopNodeUserRequest'.
-data StopNodeUserRequest_v0 =
-  StopNodeUserRequest_v0 Fid Bool (SendPort StopNodeUserReply)
-  -- ^ @StopNodeUserRequest m0nodeFid forceStop replyChannel@
   deriving (Eq, Show, Generic)
 
 -- | Request RC to stop node. Replied to by 'StopNodeUserReply' on the
@@ -123,10 +107,6 @@ data StopNodeUserRequest =
   StopNodeUserRequest Fid Bool (SendPort StopNodeUserReply) String
   -- ^ @StopNodeUserRequest m0nodeFid forceStop replyChannel reason@
   deriving (Eq, Show, Generic)
-
-instance Migrate StopNodeUserRequest where
-  type MigrateFrom StopNodeUserRequest = StopNodeUserRequest_v0
-  migrate (StopNodeUserRequest_v0 f b p) = StopNodeUserRequest f b p "unspecified"
 
 -- | Reply to 'StopNodeUserRequest'.
 data StopNodeUserReply =
@@ -164,9 +144,7 @@ deriveSafeCopy 0 'base ''StartMeroClientRequest
 deriveSafeCopy 0 'base ''StartProcessNodeNew
 deriveSafeCopy 0 'base ''StartProcessesOnNodeRequest
 deriveSafeCopy 0 'base ''StopHalonM0dRequest
-deriveSafeCopy 0 'base ''StopMeroClientRequest_v0
+deriveSafeCopy 0 'base ''StopMeroClientRequest
 deriveSafeCopy 0 'base ''StopNodeUserReply
-deriveSafeCopy 0 'base ''StopNodeUserRequest_v0
+deriveSafeCopy 0 'base ''StopNodeUserRequest
 deriveSafeCopy 0 'base ''StopProcessesOnNodeRequest
-deriveSafeCopy 1 'extension ''StopMeroClientRequest
-deriveSafeCopy 1 'extension ''StopNodeUserRequest

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Actions/Spiel.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Actions/Spiel.hs
@@ -488,7 +488,7 @@ syncToBS = loadConfData >>= \case
   Just tx -> getHalonVar _hv_mero_workers_allowed >>= \case
     True -> do
       M0.ConfUpdateVersion verno _ <- getConfUpdateVersion
-      wrk <- DP.liftIO $ newM0Worker
+      wrk <- DP.liftIO newM0Worker
       bs <- txOpenLocalContext (mkLiftRC wrk)
         >>= txPopulate (mkLiftRC wrk) tx
         >>= m0synchronously (mkLiftRC wrk) . flip txToBS verno
@@ -496,7 +496,7 @@ syncToBS = loadConfData >>= \case
       return bs
     False -> do
       phaseLog "warn" "syncToBS: returning empty string due to HalonVars"
-      return $! BS.empty
+      return BS.empty
   Nothing -> error "Cannot load configuration data from graph."
 
 data Synchronized = Synchronized (Maybe Int) (Either String ()) deriving (Generic, Show)

--- a/mero-halon/src/lib/HA/Resources/Mero.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero.hs
@@ -133,25 +133,15 @@ data SpielAddress = SpielAddress {
 instance Binary SpielAddress
 instance Hashable SpielAddress
 
-data SyncToConfd_0 =
-      SyncToConfdServersInRG_0
-    | SyncDumpToBS_0 ProcessId
-  deriving (Eq, Generic, Show, Typeable)
-
 data SyncToConfd =
       SyncToConfdServersInRG Bool
+      -- | Used by halonctl
     | SyncDumpToBS ProcessId
   deriving (Eq, Generic, Show, Typeable)
 
-instance Migrate SyncToConfd where
-  type MigrateFrom SyncToConfd = SyncToConfd_0
-  migrate SyncToConfdServersInRG_0 = SyncToConfdServersInRG False
-  migrate (SyncDumpToBS_0 p) = SyncDumpToBS p
-
 instance Hashable SyncToConfd
 storageIndex ''SyncToConfd "6990a155-7db8-48a9-91e8-d49b75d16b25"
-deriveSafeCopy 0 'base ''SyncToConfd_0
-deriveSafeCopy 1 'extension ''SyncToConfd
+deriveSafeCopy 0 'base ''SyncToConfd
 
 newtype SyncDumpToBSReply = SyncDumpToBSReply (Either String BS.ByteString)
   deriving (Eq, Generic, Show, Typeable)

--- a/mero-halon/src/lib/Mero/Notification.hs
+++ b/mero-halon/src/lib/Mero/Notification.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -363,7 +364,7 @@ initializeHAStateCallbacks lnode addr processFid profileFid haFid rmFid fbarrier
                  -- and those messages should be processed. So we fork
                  -- a worker that processes them. Because our thread
                  -- would be blocked.
-                 d <- newTVarIO False 
+                 d <- newTVarIO False
                  tid <- forkM0OS $ fix $ \loop -> do
                           et <- atomically $ (pure Nothing <* (check =<< readTVar d))
                                   `orElse` (Just <$> readTChan taskPool)

--- a/mero-halon/src/lib/Mero/Notification/HAState.hsc
+++ b/mero-halon/src/lib/Mero/Notification/HAState.hsc
@@ -166,11 +166,6 @@ data {-# CTYPE "conf/ha.h" "struct m0_conf_ha_service_event" #-}
 instance Hashable ServiceEventType
 deriveSafeCopy 0 'base ''ServiceEventType
 
-data ServiceEvent_v0 = ServiceEvent_v0
-  { _chs_event0 :: ServiceEventType
-  , _chs_type0 :: ServiceType
-  } deriving (Show, Eq, Ord, Typeable, Generic)
-
 -- | @m0_conf_ha_service@.
 data ServiceEvent = ServiceEvent
   { _chs_event :: ServiceEventType
@@ -180,12 +175,7 @@ data ServiceEvent = ServiceEvent
 
 instance Hashable ServiceEvent
 
-instance Migrate ServiceEvent where
-  type MigrateFrom ServiceEvent = ServiceEvent_v0
-  migrate (ServiceEvent_v0 e t) = ServiceEvent e t (-1)
-
-deriveSafeCopy 0 'base ''ServiceEvent_v0
-deriveSafeCopy 1 'extension ''ServiceEvent
+deriveSafeCopy 0 'base ''ServiceEvent
 
 -- | @m0_be_location@.
 data {-# CTYPE "be/ha.h" "struct m0_be_location" #-}


### PR DESCRIPTION
*Created by: Fuuzetsu*

In first migration, we do not need all migrations that we have. Simply
removed types that we do not care about preserving through offline
migration (i.e. things that aren't in graph nor would be useful in EQ).