### PR TITLE
HALON-702: Clean up halon:sspl behaviour + consume

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Job/Actions.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Job/Actions.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 -- |
--- Copyright:  (C) 2015 Seagate Technology Limited.
+-- Copyright:  (C) 2015-2017 Seagate Technology Limited.
 --
 -- Helpers that simplifies creation of the long running processes
 module HA.RecoveryCoordinator.Job.Actions
@@ -167,8 +167,8 @@ mkJobRule (Job name)
 
 -- | Start a job using the given request. Returns a listener ID that
 -- can be kept by the caller.
-startJob :: (Typeable r, SafeCopy r) => r -> PhaseM RC l ListenerId
+startJob :: (MonadProcess m, Typeable r, SafeCopy r) => r -> m ListenerId
 startJob request = do
-  l <- ListenerId <$> liftIO UUID.nextRandom
+  l <- liftProcess $ ListenerId <$> liftIO UUID.nextRandom
   promulgateRC $ JobStartRequest l request
   return l

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Actions/Core.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Actions/Core.hs
@@ -299,8 +299,8 @@ getMultimapChan = fmap lsMMChan $ get Global
 --
 -- However, 'promulgateRC' introduces additional synchronization overhead in normal
 -- case, so on a fast-path 'unsafePromulgateRC' could be used.
-promulgateRC :: (SafeCopy msg, Typeable msg) => msg -> PhaseM RC l ()
-promulgateRC msg = liftProcess $ promulgateWait msg
+promulgateRC :: (MonadProcess m, SafeCopy msg, Typeable msg) => msg -> m ()
+promulgateRC = liftProcess . promulgateWait
 
 -- | Fast-path 'promulgateRC', this call is not blocking call, so there is no guarantees
 -- of message to be persisted when RC exit 'unsafePromulgateRC' call. This call is much

--- a/mero-halon/src/lib/HA/Services/SSPL/CEP.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/CEP.hs
@@ -305,7 +305,7 @@ ruleMonitorDriveManager = defineSimpleIf "sspl::monitor-drivemanager" extract $ 
 
 -- | Handle information messages about drive changes from HPI system.
 ruleMonitorStatusHpi :: Definitions RC ()
-ruleMonitorStatusHpi = defineSimpleIf "sspl::monitor-status-hpi" extract $ \(uuid ,nid, srphi) -> do
+ruleMonitorStatusHpi = defineSimpleIf "sspl::monitor-status-hpi" extract $ \(uuid, nid, srphi) -> do
   let wwn = DIWWN . T.unpack
                   . sensorResponseMessageSensor_response_typeDisk_status_hpiWwn
                   $ srphi

--- a/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
@@ -354,7 +354,7 @@ iemSchema = genericBindConf ("sspl_iem", "iem_exchange")
 
 -- | 'Schema' for command bind configuration
 commandSchema :: Schema Rabbit.BindConf
-commandSchema = genericBindConf ("sspl_halon","systemd_exchange")
+commandSchema = genericBindConf ("sspl_halon_command","systemd_exchange")
                                 ("sspl_ll", "systemd_routingKey")
                                 ("sspl_halon", "systemd_queue")
 
@@ -363,6 +363,14 @@ commandAckSchema :: Schema Rabbit.BindConf
 commandAckSchema = genericBindConf ("sspl_command_ack", "command_ack_exchange")
                                    ("sspl_ll",      "command_ack_routing_key")
                                    ("sspl_command_ack", "command_ack_queue")
+
+-- | DCS 'Schema'. See also 'sensorSchema'.
+dcsSchema :: Schema Rabbit.BindConf
+dcsSchema = genericBindConf ("sspl_halon_sensor", "dcs_exchange")
+                            ("sspl_ll", "dcs_routingKey")
+                            (shortHostName, "dcs_queue")
+  where
+    shortHostName = unsafePerformIO $ readProcess "hostname" ["-s"] ""
 
 -- | Generic 'Schema' creating 'Rabbit.BindConf' on the given
 -- @genericBindConf exchange route queue@.
@@ -411,22 +419,6 @@ actuatorSchema = compositeOption subOpts
                 <> summary "Timeout to use when declaring channels to the RC."
                 <> metavar "MICROSECONDS"
 
--- | DCS 'Schema'. See also 'sensorSchema'.
-dcsSchema :: Schema Rabbit.BindConf
-dcsSchema = let
-    en = defaultable "sspl_halon" . strOption
-        $ long "dcs_exchange"
-        <> metavar "EXCHANGE_NAME"
-    rk = defaultable "sspl_ll" . strOption
-          $ long "dcs_routingKey"
-          <> metavar "ROUTING_KEY"
-    qn = defaultable shortHostName . strOption
-          $ long "dcs_queue"
-          <> metavar "QUEUE_NAME"
-          where
-            shortHostName = unsafePerformIO $ readProcess "hostname" ["-s"] ""
-  in Rabbit.BindConf <$> en <*> rk <*> qn
-
 -- | Sensor configuration
 data SensorConf = SensorConf {
     scDCS :: Rabbit.BindConf
@@ -463,7 +455,6 @@ data SsplLlFromSvc
   | ThreadController !NodeId !ActuatorResponseMessageActuator_response_typeThread_controller
   | ExpanderResetInternal !NodeId
   deriving (Show, Eq)
-
 
 -- | SSPL service configuration.
 data SSPLConf = SSPLConf

--- a/mero-halon/tests/HA/Test/SSPL.hs
+++ b/mero-halon/tests/HA/Test/SSPL.hs
@@ -12,273 +12,106 @@
 -- test different interations of the SSPL-LL and halon.
 --
 -- Tests:
---   -- send command from the node and check that is was received
---        dummy by SSPL-LL
---   -- send reply from SSPL-LL and check that it was received by
---        RC
---   -- sensor receives message from sspl-ll
-module HA.Test.SSPL where
+--   - send command from the node and check that is was received
+--        by dummy SSPL
+--   - halon:SSPL receives sensor message from dummy SSPL
+module HA.Test.SSPL (mkTests) where
 
 import           Control.Distributed.Process
-import           Control.Distributed.Process.Closure
-import           Control.Distributed.Process.Node
-import           Control.Distributed.Static
 import           Control.Exception as E
-import           Control.Monad (void)
 import           Data.Binary (Binary)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as LBS
-import           Data.Defaultable
-import qualified Data.HashMap.Strict as M (fromList)
-import           Data.List (isInfixOf)
-import           Data.Maybe (fromJust)
+import           Data.String (fromString)
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import           Data.Time
 import           Data.Typeable
-import qualified Data.UUID as UUID
 import           GHC.Generics
 import           HA.Aeson
-import qualified HA.Aeson as Aeson
-import           HA.Encode
-import           HA.EventQueue.Producer (promulgateEQ)
 import           HA.EventQueue.Types (HAEvent(..))
-import           HA.Multimap
-import           HA.NodeUp  (nodeUp)
-import           HA.RecoveryCoordinator.Definitions
 import           HA.RecoveryCoordinator.Helpers
 import           HA.RecoveryCoordinator.Mero
-import           HA.RecoveryCoordinator.Service.Events
-import           HA.Resources
-import           HA.SafeCopy
-import           HA.Services.SSPL hiding (header)
-import           HA.Services.SSPL.CEP (sendNodeCmd)
+import           HA.Replicator (RGroup)
 import           HA.Services.SSPL.LL.Resources
 import           HA.Services.SSPL.Rabbit
-import           HA.Startup (startupHalonNode, ignition)
+import qualified Helper.Runner as H
 import           Network.AMQP
 import           Network.CEP
 import           Network.Transport (Transport)
-import           RemoteTables ( remoteTable )
 import           SSPL.Bindings
 import           Test.Framework
 import           Test.Tasty.HUnit
-import           TestRunner
 
 newtype SChan = SChan SensorResponseMessageSensor_response_typeDisk_status_drivemanager
   deriving (Generic, Typeable)
 instance Binary SChan
 
-data TestSmartCmd = TestSmartCmd !NodeId !ByteString deriving (Generic, Typeable)
+-- | Create rabbit mq tests. This command checks if it's possible to connect
+-- to the system
+mkTests :: (Typeable g, RGroup g)
+        => Transport -> Proxy g -> IO TestTree
+mkTests transport pg = do
+  ex <- E.try $ Network.AMQP.openConnection "localhost" "/" "guest" "guest"
+  case ex of
+    Left (e :: AMQPException) -> return $
+      testCase "SSPL" $ error $ "RabbitMQ error: " ++ show e
+    Right x -> do
+      closeConnection x
+      return $ testGroup "SSPL"
+        [ testCase "RMQ proxy works" $ testProxy transport pg
+        , testCase "Sensor message reaches RC" $ testSensor transport pg
+        ]
 
-testRules :: ProcessId ->  [Definitions RC ()]
-testRules pid =
-  [ defineSimple "sspl-test-send" $ \(HAEvent _ (TestSmartCmd nid t)) -> do
-      void $ sendNodeCmd [Node nid] Nothing (SmartTest $ T.decodeUtf8 t)
-  , defineSimpleIf "sspl-test-reply" cAck $ \s -> do
-      liftProcess $ say $ "TEST-CA " ++ show s
-  , defineSimpleIf "sspl-test-sensor" statusDm $ \s -> do
-      liftProcess $ usend pid (SChan s)
-  ]
+-- | Check that RMQ proxy is running and is taking messages. This test
+-- is completely redundant because every other SSPL-using test relies
+-- on this already.
+testProxy :: (Typeable g, RGroup g) => Transport -> Proxy g -> IO ()
+testProxy t pg = H.run t pg [] $ \ts -> do
+  self <- getSelfPid
+  let exch = fromString "test-exchange"
+      queue = fromString "test-queue"
+      key = queue
+      msg = fromString "test"
+      rmq = H._rmq_pid $ H._ts_rmq ts
+  purgeRmqQueues rmq [queue]
+  usend rmq $ MQSubscribe queue self
+  usend rmq $ MQBind    exch key queue
+  usend rmq $ MQPublish exch queue msg
+  Just (MQMessage q m) <- expectTimeout (10 * 1000000)
+  liftIO $ assertEqual "Got message from correct queue" q queue
+  liftIO $ assertEqual "Got correct message back" m msg
+  purgeRmqQueues rmq [queue]
+
+-- | Send a message to RMQ proxy which should then forward it to real
+-- RMQ where it's picked up by SSPL, sent to RC and dealt with it
+-- there. We listen for the message reaching RC.
+testSensor :: (Typeable g, RGroup g) => Transport -> Proxy g -> IO ()
+testSensor t pg = H.run t pg [testRule] $ \ts -> do
+  time <- formatTimeSSPL <$> liftIO getCurrentTime
+  -- Message was taken from the logs of the real SSPL service.
+  let rawmsg = BS.concat
+        [ "{\"username\": \"sspl-ll\""
+        , ", \"description\": \"Seagate Storage Platform Library - Low Level - Sensor Response\""
+        , ", \"title\": \"SSPL-LL Sensor Response\""
+        , ", \"expires\": 3600, \"signature\": \"None\""
+        , ", \"time\": \"", BS8.pack (T.unpack time), "\""
+        , ", \"message\":  {\"sspl_ll_msg_header\": {\"msg_version\": \"1.0.0\", \"schema_version\": \"1.0.0\", \"sspl_version\": \"1.0.0\"}, \"sensor_response_type\":"
+        , "{\"disk_status_drivemanager\": {\"enclosureSN\":\"HLM1002010G2YD5\", \"serialNumber\": \"Z8402HS4\", \"diskNum\": 29, \"diskReason\": \"None\", \"diskStatus\": \"OK\", \"pathID\": \"/dev/disk/by-id/wwn-0x5000c5007b00ecf5\"}}"
+        , "}}"
+        ] :: ByteString
+      Just (Just msg) = sensorResponseMessageSensor_response_typeDisk_status_drivemanager
+        . sensorResponseMessageSensor_response_type
+        . sensorResponseMessage <$> decodeStrict rawmsg
+  sayTest "sending command"
+  withSubscription [processNodeId $ H._ts_rc ts] (Proxy :: Proxy SChan) $ do
+    H._rmq_publishSensorMsg (H._ts_rmq ts) rawmsg
+    SChan s <- expectPublished
+    liftIO $ assertEqual "Correct command received" msg s
   where
-    cAck (HAEvent _ (CAck s)) _ = return $! Just s
-    cAck _ _ = return Nothing
+    testRule :: Definitions RC ()
+    testRule = defineSimpleIf "sspl-test-sensor" statusDm $ \s -> do
+      publish $ SChan s
 
     statusDm (HAEvent _ (DiskStatusDm _ s)) _ = return $! Just s
     statusDm _ _ = return Nothing
-
-unit :: ()
-unit = ()
-
-testRC :: (ProcessId, [NodeId]) -> ProcessId -> StoreChan -> Process ()
-testRC (pid, eqNids) = recoveryCoordinatorEx () (testRules pid) eqNids
-
-remotable
-  [ 'testRC, 'testRules, 'unit ]
-
--- | Create rabbit mq tests. This command checks if it's possible to connect
--- to the system
-mkTests :: IO (Transport -> TestTree)
-mkTests = do
-  ex <- E.try $ Network.AMQP.openConnection "localhost" "/" "guest" "guest"
-  case ex of
-    Left (e::AMQPException) -> return $ \_->
-      testCase "SSPL"  $ error $ "RabbitMQ error: " ++ show e
-    Right x -> do
-      closeConnection x
-      return $ \transport ->
-        testGroup "SSPL"
-          [ testCase "proxy test" $ testProxy transport
-          , testCase "SSPL Sensor" $ testSensor transport
-          , testCase "SSPL Interface tests" $ testDelivery transport
-          ]
-
-testProxy :: Transport -> IO ()
-testProxy transport = withTmpDirectory $ do
-  E.bracket (newLocalNode transport remoteTable)
-            (closeLocalNode)
-    $ \n -> runProcess n $ do
-      pid <- spawnLocal $ rabbitMQProxy $ ConnectionConf (Configured "localhost")
-                                                         (Configured "/")
-                                                         ("guest")
-                                                         ("guest")
-      link pid
-      usend pid . MQSubscribe "test-queue" =<< getSelfPid
-      usend pid (MQBind    "test-exchange" "test-queue" "test-queue")
-      usend pid (MQPublish "test-exchange" "test-queue" "test")
-      MQMessage "test-queue" "test" <- expect
-      return ()
-
-
-runSSPLTest :: Transport
-            -> (ProcessId -> String -> Process ()) -- interseptor callback
-            -> (ProcessId -> LocalNode -> Process ()) -- actual test
-            -> Assertion
-runSSPLTest transport interseptor test =
-  runTest 2 20 15000000 transport (HA.Test.SSPL.__remoteTable remoteTable) $ \[n] -> do
-    self <- getSelfPid
-    -- Startup halon
-    let rcClosure = $(mkClosure 'recoveryCoordinatorEx) () `closureApply`
-                       ($(mkClosure 'testRules) self)
-    _ <- liftIO $ forkProcess n $ do
-      startupHalonNode rcClosure
-      usend self ()
-    () <- expect
-    let args = ( False :: Bool
-               , [localNodeId n]
-               , 1000 :: Int
-               , 1000000 :: Int
-               , $(mkClosure 'testRC) (self, [localNodeId n])
-               , 8*1000000 :: Int
-               )
-    _ <- liftIO $ forkProcess n $ ignition args >> usend self ()
-    () <- expect
-    _ <- liftIO $ forkProcess n $ do
-            nodeUp [localNodeId n]
-            usend self ()
-    () <- expect
-    _ <- liftIO $ forkProcess n $ registerInterceptor $ interseptor self
-    let ssplConf =
-          (SSPLConf (ConnectionConf (Configured "127.0.0.1")
-                                    (Configured "/")
-                                    ("guest")
-                                    ("guest"))
-                    (SensorConf   (BindConf (Configured "sspl_halon")
-                                            (Configured "sspl_ll")
-                                            (Configured "sspl_dcsque")))
-                    (ActuatorConf (BindConf (Configured "sspl_iem")
-                                            (Configured "sspl_ll")
-                                            (Configured "sspl_iem"))
-                                  (BindConf (Configured "sspl_halon")
-                                            (Configured "sspl_ll")
-                                            (Configured "sspl_halon"))
-                                  (BindConf (Configured "sspl_command_ack")
-                                            (Configured "halon_ack")
-                                            (Configured "sspl_command_ack"))
-                                  (Configured 1000000)))
-    _ <- serviceStartOnNodes [localNodeId n] sspl ssplConf [localNodeId n]
-    pid <- spawnLocal $ do
-      link self
-      rabbitMQProxy $ ConnectionConf (Configured "localhost")
-                                     (Configured "/")
-                                     ("guest")
-                                     ("guest")
-    sayTest "Clearing RMQ queues"
-    purgeRmqQueues pid [ "test-queue", "sspl_dcsque"
-                       , "sspl_iem", "sspl_command_ack"]
-    sayTest "Starting test"
-    usend pid $ MQBind    "sspl_halon" "sspl_iem" "sspl_ll"
-    usend pid $ MQSubscribe "sspl_iem" self
-    test pid n
-    sayTest "Test finished"
-    _ <- promulgateEQ [localNodeId n] $ encodeP $
-          ServiceStopRequest (Node $ localNodeId n) sspl
-    _ <- receiveTimeout 1000000 []
-    kill pid "end of game"
-
-testSensor :: Transport -> IO ()
-testSensor transport = runSSPLTest transport interseptor test
-  where
-    interseptor _ _ = return ()
-    test pid _ = do
-      t <- formatTimeSSPL <$> liftIO getCurrentTime
-      -- Message was taken from the logs of the real SSPL service.
-      let rawmsg = BS.concat
-            [ "{\"username\": \"sspl-ll\""
-            , ", \"description\": \"Seagate Storage Platform Library - Low Level - Sensor Response\""
-            , ", \"title\": \"SSPL-LL Sensor Response\""
-            , ", \"expires\": 3600, \"signature\": \"None\""
-            , ", \"time\": \"", BS8.pack (T.unpack t), "\""
-            , ", \"message\":  {\"sspl_ll_msg_header\": {\"msg_version\": \"1.0.0\", \"schema_version\": \"1.0.0\", \"sspl_version\": \"1.0.0\"}, \"sensor_response_type\":"
-            , "{\"disk_status_drivemanager\": {\"enclosureSN\":\"HLM1002010G2YD5\", \"serialNumber\": \"Z8402HS4\", \"diskNum\": 29, \"diskReason\": \"None\", \"diskStatus\": \"OK\", \"pathID\": \"/dev/disk/by-id/wwn-0x5000c5007b00ecf5\"}}"
-            , "}}"
-            ] :: ByteString
-          Just (Just msg) = sensorResponseMessageSensor_response_typeDisk_status_drivemanager
-            . sensorResponseMessageSensor_response_type
-            . sensorResponseMessage <$> decodeStrict rawmsg
-      sayTest "sending command"
-      usend pid $ MQPublish "sspl_halon" "sspl_ll" rawmsg
-      SChan s <- expect
-      liftIO $ assertEqual "Correct command received" msg s
-
-testDelivery :: Transport -> IO ()
-testDelivery transport = runSSPLTest transport interseptor test
-  where
-    interseptor self string
-      | "TEST-CA " `isInfixOf` string =
-        usend self (drop (length ("TEST-CA "::String)) string)
-    interseptor _ _ = return ()
-    test pid n = do
-      _ <- promulgateEQ [localNodeId n] (TestSmartCmd (localNodeId n) "foo")
-      MQMessage _ bs <- expect
-      let Just ActuatorRequest
-            {actuatorRequestMessage =
-              ActuatorRequestMessage
-                { actuatorRequestMessageActuator_request_type = ActuatorRequestMessageActuator_request_type
-                    { actuatorRequestMessageActuator_request_typeNode_controller
-                        = Just (ActuatorRequestMessageActuator_request_typeNode_controller cmd)
-                    }
-                , actuatorRequestMessageSspl_ll_msg_header=_header
-                }} = decodeStrict bs
-      Just (SmartTest "foo") <- return $ parseNodeCmd cmd
-
-      msgTime <- liftIO $ getCurrentTime
-      let uuid = fromJust $ UUID.fromString "c2cc10e1-57d6-4b6f-9899-38d972112d8c"
-          header = Aeson.Object $ M.fromList [
-              ("schema_version", Aeson.String "1.0.0")
-            , ("sspl_version", Aeson.String "1.0.0")
-            , ("msg_version", Aeson.String "1.0.0")
-            , ("uuid", Aeson.String . T.decodeUtf8 . UUID.toASCIIBytes $ uuid)
-            ]
-          msg = ActuatorResponse
-                  { actuatorResponseSignature = "auth_sig"
-                  , actuatorResponseTime      = formatTimeSSPL msgTime
-                  , actuatorResponseExpires   = Nothing
-                  , actuatorResponseUsername  = "ssplll"
-                  , actuatorResponseMessage   =
-                      ActuatorResponseMessage
-                        { actuatorResponseMessageActuator_response_type
-                            = ActuatorResponseMessageActuator_response_type
-                               { actuatorResponseMessageActuator_response_typeAck =
-                                  Just ActuatorResponseMessageActuator_response_typeAck
-                                    { actuatorResponseMessageActuator_response_typeAckAck_msg  = "Passed"
-                                    , actuatorResponseMessageActuator_response_typeAckAck_type =
-                                        nodeCmdString (SmartTest "foo")
-                                    }
-                               , actuatorResponseMessageActuator_response_typeThread_controller = Nothing
-                               , actuatorResponseMessageActuator_response_typeService_controller = Nothing
-                               }
-                        , actuatorResponseMessageSspl_ll_msg_header = header
-                        }
-                  }
-      usend pid $ MQPublish "sspl_command_ack" "halon_ack" (LBS.toStrict $ encode msg)
-      let scmd = "CommandAck {commandAckUUID = Just c2cc10e1-57d6-4b6f-9899-38d972112d8c"
-                  ++ ", commandAckType = Just (SmartTest \"foo\"), commandAck = AckReplyPassed}" :: String
-      s <- expect
-      liftIO $ assertEqual "Correct command received" scmd s
-      _ <- receiveTimeout 500000 []
-      return ()
-
-deriveSafeCopy 0 'base ''TestSmartCmd

--- a/mero-halon/tests/tests.hs
+++ b/mero-halon/tests/tests.hs
@@ -37,7 +37,7 @@ tests :: Transport -> (EndPointAddress -> EndPointAddress -> IO ()) -> IO TestTr
 tests transport breakConnection = do
   -- For mock replicator, change to 'Proxy RLocalGroup'
   let pg = Proxy :: Proxy RLogGroup
-  ssplTest <- HA.Test.SSPL.mkTests
+  ssplTests <- HA.Test.SSPL.mkTests transport pg
   driveFailureTests <- HA.Castor.Story.Tests.mkTests pg
   processTests <- HA.Castor.Story.Process.mkTests pg
   internalSCTests <- HA.Test.InternalStateChanges.mkTests pg
@@ -54,7 +54,7 @@ tests transport breakConnection = do
       , testGroup "Service-SSPL" $ HA.RecoveryCoordinator.SSPL.Tests.utTests transport pg
       , testGroup "ServiceInterface" $ HA.Test.ServiceInterface.tests transport pg
       , HA.Test.Disconnect.tests transport breakConnection
-      , ssplTest transport
+      , ssplTests
       ]
 
 -- | Set up a 'Transport' and a way to break connections before


### PR DESCRIPTION
*Created by: Fuuzetsu*

The service was duplicating any messages it sent to SSPL back onto the
queue that it was listening on. Worse, many tests built on top of this
behaviour.

Fix the problem by using separate exchanges binding to their own queues.
No new queues are created so everything should work without changes on
SSPL side.

Change RMQ proxy to work as a shim between tests and halon:SSPL.
Basically it pretends to be SSPL of sort.
Single-queue-multiple-consumers problem is solved by creating
proxy-internal queue that tests send to and messages are forwarded from
that onto the real queue halon:sspl receives from. This works OK because
all our exchanges are topic exchanges with 1:1 relationship to the
queues without any filtering (i.e. basically `direct` exchanges). In
other scenarios we might have had to worry whether a message was
forwarded or not at all as to not mis-report in the tests.

Add implementation into halon:sspl `teardown` service function. The
behaviour is similar to before but we wait for the internal processes to
die instead of instantly reporting success. This exposes somewhat noisy
logs of form

```
    Rebalancing drive goes back to rebalance after reset:               [Service:SSPL] Exception on channel: ConnectionClosedException "closed by user"
[SSPL-HL]: exception ConnectionClosedException "ConnectionClosedException \"closed by user\"" (src/lib/HA/Services/SSPL.hs:210:40 in mero-halon-0.1-3LmulxqZ2GHKfk7qr2okf9:HA.Services.SSPL)
```

This means we're not shutting down gently enough and should revisit this
code. I'm leaving it as-is for now (HALON-707).

Don't patch `setPhaseIfConsume` because we need to change API somehow.
Currently it's broken but the "trivial" fix of looping doesn't work.
Consider

```
setPhaseIfConsume foo …
setPhaseIfConsume bar …

directly rule_init $ do
  switch [foo, bar]
```

With "trivial" fix, `bar` never fires. Yes, it does sound like job for
dispatcher, again.