### PR TITLE
HALON-710: Clean SSPL teardown/restart.

### DIFF
--- a/mero-halon/scripts/setup-rabbitmq-perms.sh
+++ b/mero-halon/scripts/setup-rabbitmq-perms.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-HALON_USER=${HALON_USER:-sspl-ll}
-HALON_PASSWORD=${HALON_PASS:-sspl-4ever}
+HALON_USER=${HALON_USER:-sspluser}
+HALON_PASSWORD=${HALON_PASS:-sspl4ever}
 rabbitmqctl add_vhost SSPL
 rabbitmqctl add_user ${HALON_USER} "${HALON_PASSWORD}"
 rabbitmqctl set_permissions -p SSPL ${HALON_USER} '.' '.' '.*'

--- a/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
+++ b/mero-halon/src/lib/HA/Services/SSPL/LL/Resources.hs
@@ -42,6 +42,7 @@ module HA.Services.SSPL.LL.Resources
   , tryParseAckReply
   ) where
 
+import           Control.Concurrent.STM (TChan)
 import           Control.Distributed.Process (NodeId, ProcessId, SendPort)
 import           Control.Distributed.Process.Closure
 import           Control.Distributed.Static (RemoteTable)
@@ -327,12 +328,10 @@ makeLoggerMsg lc = emptyActuatorMsg {
 
 -- | Actuator channel list
 data ActuatorChannels = ActuatorChannels
-    { iemPort :: SendPort InterestingEventMessage
-    , systemdPort :: SendPort (Maybe UUID, ActuatorRequestMessageActuator_request_type)
+    { iemPort :: TChan InterestingEventMessage
+    , systemdPort :: TChan (Maybe UUID, ActuatorRequestMessageActuator_request_type)
     }
-  deriving (Show, Generic, Typeable)
-
-instance Hashable ActuatorChannels
+  deriving (Generic, Typeable)
 
 -- | Resource graph representation of a channel
 newtype Channel a = Channel (SendPort a)
@@ -556,7 +555,6 @@ myResourcesTable
 --------------------------------------------------------------------------------
 
 deriveSafeCopy 0 'base ''AckReply
-deriveSafeCopy 0 'base ''ActuatorChannels
 deriveSafeCopy 0 'base ''ActuatorConf
 deriveSafeCopy 0 'base ''CommandAck
 deriveSafeCopy 0 'base ''IPMIOp

--- a/mero-halon/tests/Helper/Runner.hs
+++ b/mero-halon/tests/Helper/Runner.hs
@@ -435,7 +435,9 @@ run' transport pg extraRules to test = do
 
       when (_to_run_sspl to) $ do
         for_ nids $ \nid -> do
-          ServiceStopRequestOk <- serviceStopOnNode [rcNodeId] sspl nid
+          serviceStopOnNode [rcNodeId] sspl nid >>= \case
+            ServiceStopRequestOk -> return ()
+            r -> fail $ "SSPL failed to stop with: " ++ show r
           return ()
         unlink (_rmq_pid rmq)
         kill (_rmq_pid rmq) "end of game"


### PR DESCRIPTION
*Created by: Fuuzetsu*

Remove seeming random MVar locking, flatten out the service a bit.
Switch directly to `TChan` and leverage `orElse` with `TVar`s for work
processing and finalisation signalling.

We now die cleanly. Move to only catching AMQPExceptions and let any
other exceptions bubble up and kill the service if needed. If we wanted
to, for simplicity we could reduce concurrency and perform RMQ calls in
single worker process. For now synchronisation is hidden in a helper.