### PR TITLE
HALON-723: Don't transition between failed states.

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Transitions.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Transitions.hs
@@ -44,6 +44,7 @@ processKeepaliveTimeout ts = Transition $ \case
 processFailed :: (?loc :: CallStack) => String -> Transition M0.Process
 processFailed m = Transition $ \case
   st@M0.PSOffline -> transitionErr ?loc st
+  (M0.PSFailed _) -> NoTransition
   _ -> TransitionTo $ M0.PSFailed m
 
 -- | HA 'M0.Process' online.


### PR DESCRIPTION
*Created by: nc6*

If a process is already failed, we shouldn't transition to another
failed state.

This is only seen when we refuse to start a process due to some conditions. In this case, we don't want to obscure the original problem.

If the process actually attempts to start, we will transition through another state, and so this will not apply.