### PR TITLE
scripts/h0: add 'path' and 'env' commands

### DIFF
--- a/scripts/h0
+++ b/scripts/h0
@@ -71,6 +71,19 @@ cmd_stop() {
     _bootstrap cluster_stop
 }
 
+cmd_path() {
+    cd "$H0_SRC_DIR"
+    echo "halon-bin: $($STACK path --local-install-root)/bin"
+    echo "mero-libs: $M0_SRC_DIR/mero/.libs"
+}
+
+cmd_env() {
+    cd "$H0_SRC_DIR"
+    echo "export PATH=\"$($STACK path --local-install-root)/bin:\$PATH\""
+    echo -n "export LD_LIBRARY_PATH=\"$M0_SRC_DIR/mero/.libs"
+    echo "\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\""
+}
+
 cmd_help() {
     local RET=${1:-0}
 
@@ -79,7 +92,7 @@ cmd_help() {
 }
 
 _exec() {
-    [ $1 = 'cmd_help' ] || echo "----- ${@#cmd_} -----" >&2
+    [[ $1 =~ ^cmd_(path|env|help)$ ]] || echo "----- ${@#cmd_} -----" >&2
     "$@"
 }
 
@@ -94,6 +107,10 @@ Commands:
     test [OPTION]...  Run unit tests.
     start             Start cluster.
     stop              Stop cluster.
+    path              Print out handy path information.
+    env               Print shell commands that, if evaluated, simplify
+                      execution of Halon binaries located in the sources
+                      directory.
     help              Show this help and exit.
 
 Environment variables:
@@ -106,7 +123,7 @@ CMD=
 OPTS=
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        setup|make|rebuild|test|start|stop|help)
+        setup|make|rebuild|test|start|stop|path|env|help)
             [[ -z $CMD ]] || _exec $CMD $OPTS
             CMD=cmd_${1//-/_}
             OPTS=;;


### PR DESCRIPTION
*Created by: chumakd*

Add two new commands that show location of Halon binaries and libraries:

  path    Show location of Halon binaries and libs.
  env     Show updated ENV variables, like PATH, which can be set
          in order to be able to run Halon binaries from source dir.

Example output:

  $ h0 path
  HALON_BIN_DIR=/data/halon/.stack-work/install/x86_64-linux/lts-8.3/8.0.2/bin
  MERO_LIB_DIR=/data/mero/mero/.libs

  $ h0 env
  PATH=/data/halon/.stack-work/install/x86_64-linux/lts-8.3/8.0.2/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
  LD_LIBRARY_PATH=/data/mero/mero/.libs: