### PR TITLE
visualize-schema: Add CLI options

### DIFF
--- a/mero-halon/scripts/visualize-schema/run-visualize
+++ b/mero-halon/scripts/visualize-schema/run-visualize
@@ -19,4 +19,4 @@ cd "$(dirname $(readlink -f $0))"
 PKG_CONFIG_PATH=$M0_SRC_DIR \
     LD_LIBRARY_PATH=$M0_SRC_DIR/mero/.libs \
     MERO_ROOT=$M0_SRC_DIR \
-    stack runhaskell visualize.hs
+    stack runhaskell visualize.hs -- "$@"

--- a/mero-halon/scripts/visualize-schema/visualize.hs
+++ b/mero-halon/scripts/visualize-schema/visualize.hs
@@ -19,6 +19,10 @@ import Mero.RemoteTables ()
 
 import HA.ResourceGraph (Cardinality(AtMostOne,Unbounded), Relation)
 import TH (RelationInfo(..), resources, sep)
+
+import Options.Applicative (execParser, help, helper, info, long, switch)
+import Control.Applicative ((<**>))
+import Data.Semigroup ((<>))
 import Data.List (intersperse, isPrefixOf)
 
 data Fmt = FmtRaw | FmtDot
@@ -71,5 +75,12 @@ shorten' = reprefix [ ("HA.Service.Internal", "SvcI")
       | (prefix ++ ".") `isPrefixOf` str = subst ++ drop (length prefix) str
       | otherwise = reprefix rest str
 
+data Options = Options { optRawP :: Bool }
+
 main :: IO ()
-main = putStrLn $ repr FmtDot $(resources ''Relation)
+main = do
+    opts <- execParser $ info (optsParser <**> helper) mempty
+    let fmt = if optRawP opts then FmtRaw else FmtDot
+    putStrLn $ repr fmt $(resources ''Relation)
+  where
+    optsParser = Options <$> switch (long "raw" <> help "Raw output")

--- a/mero-halon/src/halonctl/Main.hs
+++ b/mero-halon/src/halonctl/Main.hs
@@ -35,7 +35,6 @@ import           System.Environment (getProgName)
 import           System.Process (readProcess)
 import           Version.Read
 
-
 printHeader :: IO ()
 printHeader = putStrLn "This is halonctl/TCP"
 
@@ -48,7 +47,6 @@ main = getOptions >>= maybe version run
     version = do
       printHeader
       versionString >>= putStrLn
-
 
 data Options = Options
     { optTheirAddress :: ![String] -- ^ Addresses of halond nodes to control.
@@ -109,7 +107,7 @@ getOptions = do
     trim = filter (liftA2 (||) isAlphaNum isPunctuation)
 
 run :: Options -> IO ()
-run (Options { .. }) =
+run Options{..} =
   let (hostname, _:port) = break (== ':') optOurAddress in
   bracket (either (error . show) id <$>
                TCP.createTransport hostname port


### PR DESCRIPTION
*Created by: vvv*

```
$ scripts/visualize-schema -h
Usage: visualize.hs [--raw]

Available options:
  --raw                    Raw output
  -h,--help                Show this help text
$ 
$ scripts/visualize-schema | head -3
digraph ResourceGraphSchema {
    "R.Cluster" -> "SvcI.Service-Svcs.Ping.PingConf" [label="SvcI.Supports"]
    "R.Cluster" -> "SvcI.Service-Svcs.Noisy.NoisyConf" [label="SvcI.Supports"]
visualize.hs: <stdout>: hPutChar: resource vanished (Broken pipe)
$ 
$ scripts/visualize-schema --raw | head -3
R.Cluster SvcI.Supports SvcI.Service-Svcs.Ping.PingConf AtMostOne AtMostOne
R.Cluster SvcI.Supports SvcI.Service-Svcs.Noisy.NoisyConf AtMostOne AtMostOne
SvcI.Service-Svcs.Noisy.NoisyConf Svcs.Noisy.HasPingCount Svcs.Noisy.NoisyPingCount Unbounded AtMostOne
visualize.hs: <stdout>: hPutChar: resource vanished (Broken pipe)
```