### PR TITLE
rpm: enable override of the default rpmbuild output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,47 +5,61 @@ BUILD_NUMBER = 000
 VERSION = $(shell git describe --long --always | tr '-' '_')
 MOCK_CONFIG = default
 SRC_RPM_DIR := $(shell mktemp -du)
-RESULT_DIR = rpmbuild
+RPMBUILD_DIR = rpmbuild
 
 .PHONY: rpm
 rpm:
-	mkdir -p $(RESULT_DIR)
+	mkdir -p $(RPMBUILD_DIR)
 	echo "module Version where \
 	      gitDescribe = \"$(shell git describe --long --always || echo UNKNOWN)\"; \
 	      gitCommitHash = \"$(shell git rev-parse HEAD || echo UNKNOWN)\"; \
 	      gitCommitDate = \"$(shell git log -1 --format='%cd' || echo UNKNOWN)\";" \
           > mero-halon/src/lib/Version.hs
-	git archive --format=tar --prefix=halon/ HEAD | gzip > $(RESULT_DIR)/halon.tar.gz
+	git archive --format=tar --prefix=halon/ HEAD | gzip > $(RPMBUILD_DIR)/halon.tar.gz
 	mock -r $(MOCK_CONFIG) --buildsrpm \
-		--spec halon.spec --sources $(RESULT_DIR) \
+		--spec halon.spec --sources $(RPMBUILD_DIR) \
 		--resultdir $(SRC_RPM_DIR) \
 		--define "_gitversion ${VERSION}" \
 		--define "_buildnumber ${BUILD_NUMBER}"
 	mock -r $(MOCK_CONFIG) --rebuild $(SRC_RPM_DIR)/*.src.rpm \
-		--resultdir $(RESULT_DIR) \
+		--resultdir $(RPMBUILD_DIR) \
     --define "_gitversion ${VERSION}" \
 		--define "_buildnumber ${BUILD_NUMBER}"
 
-# This target will generate a distributable RPM based on the current
-# checkout. It will generate a binary RPM in ./rpmbuild/RPMS/x86_64
-# and a pseudo-source tar in ./rpmbuild/SRPMS
+ifeq ($(RPMBUILD_DIR),rpmbuild)
+    RPMBUILD_TOPDIR := $(CURDIR)/$(RPMBUILD_DIR)
+else
+    RPMBUILD_TOPDIR := $(RPMBUILD_DIR)
+endif
+
+# This target will generate a distributable RPM based on the current checkout.
+# By default, it will generate a binary RPM in ./rpmbuild/RPMS/x86_64 and
+# a pseudo-source tar in ./rpmbuild/SRPMS. It's possible to override the default
+# output location by specifying a new value of RPMBUILD_DIR variable in the
+# command-line, e.g. `make rpm-dev RPMBUILD_DIR=~/rpmbuild`.
 rpm-dev:
-	mkdir -p rpmbuild/SOURCES/role_maps
-	mkdir -p rpmbuild/SOURCES/systemd
-	mkdir -p rpmbuild/SOURCES/tmpfiles.d
-	cp .stack-work/install/x86_64-linux/lts-8.3/8.0.2/bin/halond rpmbuild/SOURCES/
-	cp .stack-work/install/x86_64-linux/lts-8.3/8.0.2/bin/halonctl rpmbuild/SOURCES/
-	cp .stack-work/install/x86_64-linux/lts-8.3/8.0.2/bin/halon-cleanup rpmbuild/SOURCES/
-	cp systemd/halond.service rpmbuild/SOURCES/
-	cp systemd/halon-satellite.service rpmbuild/SOURCES/
-	cp systemd/halon-cleanup.service rpmbuild/SOURCES/
-	cp systemd/sysconfig/halond.example rpmbuild/SOURCES/
-	cp mero-halon/scripts/localcluster rpmbuild/SOURCES/halon-simplelocalcluster
-	cp mero-halon/scripts/hctl rpmbuild/SOURCES/hctl
-	cp mero-halon/scripts/setup-rabbitmq-perms.sh rpmbuild/SOURCES/setup-rabbitmq-perms.sh
-	cp mero-halon/scripts/mero_clovis_role_mappings.ede rpmbuild/SOURCES/role_maps/clovis.ede
-	cp mero-halon/scripts/mero_provisioner_role_mappings.ede rpmbuild/SOURCES/role_maps/prov.ede
-	cp mero-halon/scripts/mero_s3server_role_mappings.ede rpmbuild/SOURCES/role_maps/s3server.ede
-	cp mero-halon/scripts/halon_roles.yaml rpmbuild/SOURCES/role_maps/halon_role_mappings
-	cp mero-halon/scripts/tmpfiles.d/halond.conf rpmbuild/SOURCES/tmpfiles.d/halond.conf
-	rpmbuild --define "_topdir ${PWD}/rpmbuild" --define "_gitversion ${VERSION}" -ba halon-dev.spec
+	mkdir -p $(RPMBUILD_DIR)
+	mkdir -p $(RPMBUILD_DIR)/SOURCES/role_maps
+	mkdir -p $(RPMBUILD_DIR)/SOURCES/systemd
+	mkdir -p $(RPMBUILD_DIR)/SOURCES/tmpfiles.d
+	mkdir -p $(RPMBUILD_DIR)/SPECS
+	cp .stack-work/install/x86_64-linux/lts-8.3/8.0.2/bin/halond $(RPMBUILD_DIR)/SOURCES/
+	cp .stack-work/install/x86_64-linux/lts-8.3/8.0.2/bin/halonctl $(RPMBUILD_DIR)/SOURCES/
+	cp .stack-work/install/x86_64-linux/lts-8.3/8.0.2/bin/halon-cleanup $(RPMBUILD_DIR)/SOURCES/
+	cp systemd/halond.service $(RPMBUILD_DIR)/SOURCES/
+	cp systemd/halon-satellite.service $(RPMBUILD_DIR)/SOURCES/
+	cp systemd/halon-cleanup.service $(RPMBUILD_DIR)/SOURCES/
+	cp systemd/sysconfig/halond.example $(RPMBUILD_DIR)/SOURCES/
+	cp mero-halon/scripts/localcluster $(RPMBUILD_DIR)/SOURCES/halon-simplelocalcluster
+	cp mero-halon/scripts/hctl $(RPMBUILD_DIR)/SOURCES/hctl
+	cp mero-halon/scripts/setup-rabbitmq-perms.sh $(RPMBUILD_DIR)/SOURCES/setup-rabbitmq-perms.sh
+	cp mero-halon/scripts/mero_clovis_role_mappings.ede $(RPMBUILD_DIR)/SOURCES/role_maps/clovis.ede
+	cp mero-halon/scripts/mero_provisioner_role_mappings.ede $(RPMBUILD_DIR)/SOURCES/role_maps/prov.ede
+	cp mero-halon/scripts/mero_s3server_role_mappings.ede $(RPMBUILD_DIR)/SOURCES/role_maps/s3server.ede
+	cp mero-halon/scripts/halon_roles.yaml $(RPMBUILD_DIR)/SOURCES/role_maps/halon_role_mappings
+	cp mero-halon/scripts/tmpfiles.d/halond.conf $(RPMBUILD_DIR)/SOURCES/tmpfiles.d/halond.conf
+	cp halon-dev.spec $(RPMBUILD_DIR)/SPECS/
+	chown -R $$(id -u):$$(id -g) $(RPMBUILD_DIR)/
+	rpmbuild --define "_topdir $(RPMBUILD_TOPDIR)" \
+		 --define "_gitversion ${VERSION}" \
+		 -ba $(RPMBUILD_DIR)/SPECS/halon-dev.spec


### PR DESCRIPTION
*Created by: chumakd*

By default `make rpm-dev` command sets up a working directory for
`rpmbuild` inside top-level Halon source tree directory. Usually it
doesn't matter, but when Halon sources are on a filesystem like NFS or
HGFS (VMware shared directory) it can be a problem due to file ownership
and permission requirements - `rpmbuild` reports "Bad owner/group" error
if some of the file permissions don't match current user/group ID. For
example if "spec" file belongs to a different user or it's access
permissions are too lax. In such situation the most convenient way of
satisfying `rpmbuild` requirements is to create it's working directory
on a local filesystem outside of Halon source tree, which now can be
done by setting makefile variable on a command-line:

    make rpm-dev RPMBUILD_DIR=~/rpmbuild