### PR TITLE
scripts/h0: Fix word splitting issue

### DIFF
--- a/scripts/h0
+++ b/scripts/h0
@@ -176,25 +176,32 @@ EOF
 cd "$H0_SRC_DIR"
 
 CMD=
-OPTS=
+OPTS=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
         setup|make|rebuild|test|path|env|clean|help) ;& # fall through
         install|uninstall|start|stop)
-            [[ -z $CMD ]] || _exec $CMD $OPTS
+            [[ -z $CMD ]] || {
+                if [[ ${#OPTS[@]} == 0 ]]; then
+                    _exec $CMD
+                else
+                    _exec $CMD "${OPTS[@]}"
+                fi
+            }
             CMD=cmd_${1//-/_}
-            OPTS=;;
+            OPTS=();;
         *)
             [[ -n $CMD ]] || {
                 echo "Invalid command: $1" >&2
                 die "Type \`$PROG help' for usage."
             }
-            OPTS+=" $1";;
+            OPTS+=("$1");;
     esac
     shift
 done
-if [[ -n $CMD ]]; then
-    _exec $CMD $OPTS
+[[ -n $CMD ]] || cmd_help 1  # exits
+if [[ ${#OPTS[@]} == 0 ]]; then
+    _exec $CMD
 else
-    cmd_help 1
+    _exec $CMD "${OPTS[@]}"
 fi


### PR DESCRIPTION
*Created by: vvv*

Due to the bug in initial implementation, `h0 test -p 'stop then start'` used to be recognized as a sequence of `h0 test -p`, `h0 stop then`, and `h0 start` commands.  This patch fixes this problem; now `'stop then start'` is properly treated as an argument of `-p` option and is not split into separate words.