### PR TITLE
Mero/Rules.hs: fix s3server startup on mero stop/start

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Rules.hs
@@ -131,6 +131,7 @@ ruleDixInit = mkJobRule jobDixInit args $ \(JobHandle _ finish) -> do
             Log.rcLog' Log.DEBUG "DIX subsystem already initialised."
             modify Local $ rlens fldRep .~
               Field (Just $ DixInitSuccess)
+            continue finish
           else Log.withLocalContext' $ do
             Log.tagLocalContext node Nothing
             Log.rcLog Log.DEBUG "Initialising DIX subsystem"


### PR DESCRIPTION
*Created by: andriytk*

Apparently, this case was never tested before. s3server just
never started anymore on cluster stop/start because of this
silly bug in ruleDixInit code for the case when the DIX is
already initialised.