### PR TITLE
HALON-797: UT: fix sendProcessEvents:guessProcessType()

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Job/Actions.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Job/Actions.hs
@@ -128,7 +128,7 @@ mkJobRule (Job name)
                 Right (def, next) -> fork CopyNewerBuffer $ do
                   modify Local $ rlens fldReply . rfield .~ Just def
                   Log.tagContext Log.SM [ ("request", show request)
-                                        , ("uuid", show eid)
+                                        , ("eid", show eid)
                                         , ("listeners", show listeners)
                                         ] Nothing
                   insertWithStorageMapRC (mappend) input (JobDescription [eid] listeners)

--- a/rfc/013-recovery-coordinator.md
+++ b/rfc/013-recovery-coordinator.md
@@ -290,7 +290,7 @@ rcInitial = [SM "node-restart" softSSPL [] undefined
 The initial recovery co-ordinator consists of a single state machine in its
 first phase, with no messages in the buffer and some undefined state.
 
-Now let us suppose that a `HostRestartRequest node1` message arrives. The type
+Now let us suppose that a `NodeRestartRequest node1` message arrives. The type
 of message is looked up in the map, and the state machine(s) corresponding to
 that rule are looked up and run. The execution of the state machine takes three
 steps:


### PR DESCRIPTION
*Created by: andriytk*

It could guess wrong process type in a cases, when CST_CAS
service or CST_ADDB2 service (or any not present in
the comparison list) was provided in the argument list.
In fact, it did set TAG_M0_CONF_HA_PROCESS_KERNEL type
for all the TAG_M0_CONF_HA_PROCESS_M0D type cases in the
stop-start UT.

Now we fixed the algorithm to specify in the matching list
only the services which are possible for server (M0D)
processes only. And if any of those services is present
in the argument list - it means we are dealing with M0D.
The algorithm will still work in case when some new unknown
services will be introduced in future to M0D (given that
it would not be the single one configured for M0D process).

The patch to the UT detected the race problem with services
offline notifications ACKs and ruleProcessStop. The latter
does not wait for these ACKs and proceeds with stopping.
After  stop completes the stop-start UT continues with
starting, but the stale ACKs would still come and affect
the new services states already. As result, the UT did not
pass.

We fixed this by ignoring the offline notification ACKs
for services in the notification-handler.  This also might
fix a subtle race cases with cluster stop command on a
big cluster configurations when some ACKs may not come
from already stopped processes in which case the command
will fail with a timeout.