### PR TITLE
cep: minor fixes for profiling compilation

### DIFF
--- a/cep/cep/cep.cabal
+++ b/cep/cep/cep.cabal
@@ -9,7 +9,7 @@ build-type:          Simple
 -- extra-source-files:
 cabal-version:       >=1.10
 
--- ghc-heap-view cannot be built with profiling, does we need to drop
+-- ghc-heap-view cannot be built with profiling, so we need to drop
 -- ghc-datasize which depends on it.
 Flag profiling
   Description: Drop dependencies which can't be built with profiling enabled.

--- a/cep/cep/src/Network/CEP/Engine.hs
+++ b/cep/cep/src/Network/CEP/Engine.hs
@@ -40,8 +40,8 @@ import           Control.Lens
 import GHC.Generics
 #ifdef VERSION_ghc_datasize
 import GHC.DataSize (recursiveSize)
-#endif
 import System.IO.Unsafe (unsafePerformIO)
+#endif
 import System.Clock
 
 import Data.PersistMessage
@@ -334,7 +334,7 @@ defaultHandler st _ (Query (GetSetting s)) =
       EngineInitRulePassed -> _machInitRulePassed st
       EngineIsRunning      -> not (null (_machRunningSM st))
       EngineNextEvent      -> (\(_,x,_) -> x) <$> PSQ.findMin (_machEvents st)
-defaultHandler st _ (Query (GetRuntimeInfo mem RuntimeInfoTotal)) =
+defaultHandler st _ (Query (GetRuntimeInfo _mem RuntimeInfoTotal)) =
     let running = _machRunningSM st
         suspended = _machSuspendedSM st
         mRunning = M.fromListWith (+)
@@ -344,7 +344,7 @@ defaultHandler st _ (Query (GetRuntimeInfo mem RuntimeInfoTotal)) =
         nRunning = length running
         nSuspended = length suspended
 #ifdef VERSION_ghc_datasize
-        minfo = if mem
+        minfo = if _mem
                 then Just $ MemoryInfo
                   { minfoTotalSize = unsafePerformIO $ recursiveSize st
                   , minfoSMSize = unsafePerformIO (recursiveSize running)


### PR DESCRIPTION
*Created by: andriytk*

FYI: use `--flag cep:profiling' stack option for
profiling compilation of cep module.