### PR TITLE
stack.yaml: use aeson-schema from corporate github

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -30,7 +30,7 @@ packages:
     commit: 52f4c1c96c776ca74bf9f9b01808b0c1d5e0ac94
   extra-dep: true
 - location:
-    git: https://github.com/Fuuzetsu/aeson-schema.git
+    git: https://github.com/seagate-ssg/aeson-schema.git
     commit: 04de4b1f3876e5d8010d32a3bde4be7a7ae9d36a
   extra-dep: true
 


### PR DESCRIPTION
*Created by: andriytk*

Use aeson-schema from corporate github. This allows to
1) avoid dependency on 3rd party github repos and
2) make our own custom updates, like dependency restriction
   updates.

aeson-schema package is available on hackage and we could use it,
but looks like it was not updated there for a while. For example,
it does not allow to update resolver to lts-9.x versions.