### PR TITLE
s/MERO_ROOT/M0_SRC_DIR/

### DIFF
--- a/mero-halon/scripts/visualize-schema/run-visualize
+++ b/mero-halon/scripts/visualize-schema/run-visualize
@@ -18,5 +18,4 @@ export M0_SRC_DIR=${M0_SRC_DIR:-${H0_SRC_DIR%/*}/mero}
 cd "$(dirname $(readlink -f $0))"
 PKG_CONFIG_PATH=$M0_SRC_DIR \
     LD_LIBRARY_PATH=$M0_SRC_DIR/mero/.libs \
-    MERO_ROOT=$M0_SRC_DIR \
     stack runhaskell visualize.hs -- "$@"

--- a/mero-halon/tests/Bootstrap/Server.hs
+++ b/mero-halon/tests/Bootstrap/Server.hs
@@ -84,7 +84,7 @@ main =
     putStrLn $ "Calling test with sudo ..."
     mld <- fmap ("LD_LIBRARY_PATH=" ++) <$> lookupEnv "LD_LIBRARY_PATH"
     mtl <- fmap ("DC_HOST_IP=" ++) <$> lookupEnv "DC_HOST_IP"
-    mmr <- fmap ("MERO_ROOT=" ++) <$> lookupEnv "MERO_ROOT"
+    mmr <- fmap ("M0_SRC_DIR=" ++) <$> lookupEnv "M0_SRC_DIR"
     tracing <- fmap ("HALON_TRACING=" ++) <$> lookupEnv "HALON_TRACING"
     units <- fmap (\s -> "SYSTEMD_UNIT_PATHS=" ++ s ++ ":") <$> lookupEnv "SYSTEMD_UNIT_PATHS"
     callProcess "sudo" $ catMaybes [mld, mtl, mmr, units, tracing] ++ prog : argv

--- a/mero-halon/tests/HA/Test/Distributed/Helpers.hs
+++ b/mero-halon/tests/HA/Test/Distributed/Helpers.hs
@@ -45,7 +45,7 @@ pingStartedLine = "[Service:ping] starting at "
 -- | Copy mero system library and its dependencies to the given hosts
 copyMeroLibs :: MonadIO m => HostName -> [HostName] -> m ()
 copyMeroLibs lh ms = liftIO $ do
-  meroPath <- fromMaybe "/mero" <$> lookupEnv "MERO_ROOT"
+  meroPath <- fromMaybe "/mero" <$> lookupEnv "M0_SRC_DIR"
   copyFilesMove lh ms
     [ (meroPath </> "mero/.libs/libmero.so.1", "/usr/lib64/libmero.so.1", "libmero.so.1")
     , ("/lib64/libaio.so.1", "/usr/lib64/libaio.so.1", "libaio.so.1")

--- a/mero-halon/tests/Helper/Environment.hs
+++ b/mero-halon/tests/Helper/Environment.hs
@@ -20,8 +20,8 @@ import Text.Read (readMaybe)
 import Data.Foldable (for_)
 
 withMeroRoot :: (String -> IO a) -> IO a
-withMeroRoot f = lookupEnv "MERO_ROOT" >>= \case
-  Nothing -> error "Please specify MERO_ROOT environment variable in order to run test."
+withMeroRoot f = lookupEnv "M0_SRC_DIR" >>= \case
+  Nothing -> error "Please specify M0_SRC_DIR environment variable in order to run test."
   Just x  -> f x
 
 -- | Return the value of the @TEST_LISTEN@ environment variable split

--- a/mero-integration/src/test-stha-local/test-stha-local.hs
+++ b/mero-integration/src/test-stha-local/test-stha-local.hs
@@ -67,7 +67,7 @@ main =
       putStrLn $ "Calling test with sudo ..."
       mld <- fmap ("LD_LIBRARY_PATH=" ++) <$> lookupEnv "LD_LIBRARY_PATH"
       mtl <- fmap ("DC_HOST_IP=" ++) <$> lookupEnv "DC_HOST_IP"
-      mmr <- fmap ("MERO_ROOT=" ++) <$> lookupEnv "MERO_ROOT"
+      mmr <- fmap ("M0_SRC_DIR=" ++) <$> lookupEnv "M0_SRC_DIR"
       callProcess "sudo" $ catMaybes [mld, mtl, mmr] ++ prog : argv
       exitSuccess
 
@@ -91,7 +91,7 @@ main =
 
       let halonctl = "cd " ++ tmp0 ++ "; " ++ buildPath </> "halonctl/halonctl"
           halond = "cd " ++ tmp1 ++ "; " ++ buildPath </> "halond/halond"
-          m0note = "cd " ++ tmp2 ++ "; $MERO_ROOT/ha/st/m0note"
+          m0note = "cd " ++ tmp2 ++ "; $M0_SRC_DIR/ha/st/m0note"
 
       getSelfPid >>= copyLog (const True)
 

--- a/network-transport-rpc/Makefile
+++ b/network-transport-rpc/Makefile
@@ -6,21 +6,21 @@
 
 CABAL = cabal $(CABAL_SANDBOX)
 
-ifndef MERO_ROOT
-$(error The variable MERO_ROOT is undefined. Please, make it point to the mero build tree.)
+ifndef M0_SRC_DIR
+$(error The variable M0_SRC_DIR is undefined. Please, make it point to the mero build tree.)
 endif
 
-FF2C=$(MERO_ROOT)/xcode/ff2c/ff2c
+FF2C=$(M0_SRC_DIR)/xcode/ff2c/ff2c
 
-#libdirs=$(MERO_ROOT)/xcode/ff2c/.libs\
-#		$(MERO_ROOT)/net/test/.libs\
-#		$(MERO_ROOT)/extra-libs/galois/src/.libs\
-#		$(MERO_ROOT)/mero/.libs\
-#		$(MERO_ROOT)/extra-libs/db4/build_unix\
-#		$(MERO_ROOT)/extra-libs/cunit/CUnit/Sources/.libs\
-#		$(MERO_ROOT)/ut/.libs
+#libdirs=$(M0_SRC_DIR)/xcode/ff2c/.libs\
+#		$(M0_SRC_DIR)/net/test/.libs\
+#		$(M0_SRC_DIR)/extra-libs/galois/src/.libs\
+#		$(M0_SRC_DIR)/mero/.libs\
+#		$(M0_SRC_DIR)/extra-libs/db4/build_unix\
+#		$(M0_SRC_DIR)/extra-libs/cunit/CUnit/Sources/.libs\
+#		$(M0_SRC_DIR)/ut/.libs
 
-libdirs=$(MERO_ROOT)/mero/.libs
+libdirs=$(M0_SRC_DIR)/mero/.libs
 
 empty=
 sp=$(empty) $(empty)
@@ -29,7 +29,7 @@ ENV=LD_LIBRARY_PATH=$(subst $(sp),:,$(libdirs)) NTR_DB_DIR=$(NTR_DB_DIR)
 
 LD_SEARCH_PATH=$(foreach dir,$(libdirs),-L$(dir))
 HLD_SEARCH_PATH=$(foreach dir,$(libdirs),--extra-lib-dirs=$(dir))
-EXTRAINCLUDE=--extra-include-dirs=$(MERO_ROOT)
+EXTRAINCLUDE=--extra-include-dirs=$(M0_SRC_DIR)
 
 #PROF_FLAGS=--enable-library-profiling --enable-executable-profiling
 PROF_FLAGS=
@@ -66,10 +66,10 @@ test: testnt testch testtransport
 
 loadmero:
 	sudo sysctl -w kernel.randomize_va_space=0
-	sudo GENDERS=$(GENDERS) M0_CORE_DIR=$(MERO_ROOT) ./rpclite/st insmod
+	sudo GENDERS=$(GENDERS) M0_CORE_DIR=$(M0_SRC_DIR) ./rpclite/st insmod
 
 unloadmero:
-	sudo GENDERS=$(GENDERS) M0_CORE_DIR=$(MERO_ROOT) ./rpclite/st rmmod
+	sudo GENDERS=$(GENDERS) M0_CORE_DIR=$(M0_SRC_DIR) ./rpclite/st rmmod
 
 testrpcliteclient:
 	sudo $(ENV) dist/build/testrpclite/testrpclite

--- a/network-transport-rpc/README
+++ b/network-transport-rpc/README
@@ -21,7 +21,7 @@ For details about the C implementation of rpclite see rpclite/README.
 
 == Building ==
 
-See Makefile. It contains a variable MERO_ROOT which should be set to
+See Makefile. It contains a variable M0_SRC_DIR which should be set to
 the root of the mero build tree.
 
 Then typing

--- a/rpclite/Setup.hs
+++ b/rpclite/Setup.hs
@@ -17,7 +17,7 @@ rpclite_build :: PackageDescription
               -> BuildFlags
               -> IO ()
 rpclite_build pd lbi uh bf@(BuildFlags { buildVerbosity = vf }) = do
-  mero_root <- lookupEnv "MERO_ROOT"
+  mero_root <- lookupEnv "M0_SRC_DIR"
   let v = fromFlagOrDefault normal vf
       ff2c = fmap (++ "/xcode/ff2c/m0ff2c") mero_root
       progdb = userMaybeSpecifyPath "m0ff2c" ff2c $ withPrograms lbi

--- a/scripts/h0
+++ b/scripts/h0
@@ -36,7 +36,6 @@ cmd_setup() {
 
 _stack_build() {
     PKG_CONFIG_PATH=$M0_SRC_DIR \
-    MERO_ROOT=$M0_SRC_DIR \
     stack build --ghc-options="${GHC_OPTS:--g -j4}" \
         --extra-include-dirs="$M0_SRC_DIR" \
         --extra-lib-dirs="$M0_SRC_DIR/mero/.libs" \

--- a/scripts/run-additional-tests.sh
+++ b/scripts/run-additional-tests.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ ! -d $MERO_ROOT ] ; then
-	echo "MERO_ROOT environment variable should be set."
-	exit 1;
+if [ ! -d $M0_SRC_DIR ] ; then
+	echo "M0_SRC_DIR environment variable should be set."
+	exit 1
 fi
 
 if [[ `id -u` != 0  ]] ; then

--- a/stack.yaml
+++ b/stack.yaml
@@ -53,8 +53,8 @@ docker:
   registry-login: true
   # XXX To route around GHC bug #11042
   env:
+  - M0_SRC_DIR=/mero
   - LD_LIBRARY_PATH=/mero/mero/.libs
-  - MERO_ROOT=/mero
   - USER=stack # for m0 script
   - TEST_LISTEN=127.0.0.1:8090
 


### PR DESCRIPTION
*Created by: vvv*

We don't need two names (`MERO_ROOT` and `M0_SRC_DIR`) to denote
the same thing.  Let us stick with the name used by Mero team.