### PR TITLE
cep/tests: Fix "Exception can be handled" unit test

### DIFF
--- a/cep/cep/tests/Tests.hs
+++ b/cep/cep/tests/Tests.hs
@@ -13,7 +13,7 @@ import Control.Monad.Catch (SomeException(..), catch, try, throwM)
 import Control.Exception (Exception, fromException)
 import Data.Binary (Binary)
 import Data.Typeable
-import Data.List (sort)
+import Data.List (isPrefixOf, sort)
 import Data.IORef
 import Data.PersistMessage
 import HA.SafeCopy
@@ -1203,7 +1203,7 @@ exceptionWorks = do
     usend pid donut
 
     i <- expect
-    assertEqual "Ph2 should fire first" "foo" i
+    assertBool "Ph2 should fire first" $ "foo" `isPrefixOf` i
 
 newtype MyE = MyE String deriving (Show, Typeable, Eq, Binary)
 


### PR DESCRIPTION
*Created by: vvv*

String representation of an exception consists of error message and call stack.  The original unit test expected error message only.

Before:
```
      Exception
        Exception can be handled:                         FAIL
          Ph2 should fire first
          expected: "foo"
           but got: "foo\nCallStack (from HasCallStack):\n  error, called at tests/Tests.hs:1198:28 in main:Tests"
```
After:
```
      Exception
        Exception can be handled:                         OK
```