### PR TITLE
stack.yaml: Use `-O0` for distributed-process

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -41,11 +41,11 @@ extra-deps:
 
 ghc-options:
   # XXX `CEP.regression.fork-remove-messages` UT will fail unless
-  # `distributed-process` package is built with `-g` or `-O0` option;
+  # `distributed-process` package is built with `-O0` option;
   # see https://github.com/seagate-ssg/halon/pull/1425#issuecomment-399595953
   #
   # TODO: Find the root cause of the problem.
-  distributed-process: -g
+  distributed-process: -O0
 
 docker:
   enable: false


### PR DESCRIPTION
*Created by: vvv*

Turn off optimisation when compiling `distributed-process` package.
For some reason this lets "fork-remove-messages" unit test of `cep`
package pass.  Without this patch:

    cep-0.1.0.0: test (suite: unit-tests, args: -p fork-remove-messages)

    CEP - Unit tests
      regression
        fork-remove-messages: FAIL (0.01s)
          foo
          expected: ["load","work1","load","work3","load","work5"]
           but got: ["load","load","work1","work3","load","work5"]

    1 out of 1 tests failed (0.02s)

See also https://github.com/seagate-ssg/halon/pull/1425#issuecomment-399595953 and #1428.