### PR TITLE
Get rid of obsolete timeSpecAsNanoSecs

### DIFF
--- a/cep/cep/src/Network/CEP.hs
+++ b/cep/cep/src/Network/CEP.hs
@@ -313,8 +313,8 @@ runItForever start_eng = do
             go eng . Just =<< receiveWait all_events
           Just t  -> do
             p' <- liftIO $ getTime Monotonic
-            let tm = (\(TimeSpec s ns) -> (s*10^(9::Int) + ns) `div` 1000 ) $ p' `diffTimeSpec` t
-            liftIO $ traceMarkerIO $ "cep loop: blocked for " ++ show tm ++ "ms"
+            let tm = (toNanoSecs $ p' `diffTimeSpec` t) `div` 1000
+            liftIO . traceMarkerIO $ "cep loop: blocked for " ++ show tm ++ "us"
             mmsg <- receiveTimeout (fromIntegral tm) all_events
             case mmsg of
               Nothing -> do eng'' <- snd <$> stepForward (timeoutMsg p') eng

--- a/distributed-process-scheduler/src/System/Clock.hs
+++ b/distributed-process-scheduler/src/System/Clock.hs
@@ -11,7 +11,7 @@ module System.Clock
   , C.Clock(..)
   , C.TimeSpec(..)
   , C.diffTimeSpec
-  , timeSpecAsNanoSecs
+  , C.toNanoSecs
   ) where
 
 import           Control.Concurrent.MVar
@@ -46,10 +46,3 @@ schedGetTime C.Monotonic = do
     let (q, r) = divMod (t :: Int) (1000 * 1000)
     return $ C.TimeSpec (fromIntegral q) (fromIntegral $ r * 1000)
 schedGetTime c = error $ "scheduler.schedGetTime not defined for " ++ show c
-
--- | Converts a TimeSpec as nano seconds.
-timeSpecAsNanoSecs :: C.TimeSpec -> Integer
-timeSpecAsNanoSecs t = toInteger (C.sec t) * nanos + toInteger (C.nsec t)
-  where
-    nanos :: Integer
-    nanos = 10 ^ (9 :: Integer)

--- a/replicated-log/benchmarks/state-distributed.hs
+++ b/replicated-log/benchmarks/state-distributed.hs
@@ -82,7 +82,7 @@ time_ act = do
   act
   end <- liftIO $ getTime Monotonic
   let !delta = diffTimeSpec end start
-  return $ fromIntegral (timeSpecAsNanoSecs delta) / 10^(9 :: Int)
+  return $ fromIntegral $ toNanoSecs delta `div` 10^(9::Int)
 
 -- | Convert a number of seconds to a string.  The string will consist
 -- of four decimal places, followed by a short description of the time

--- a/replicated-log/benchmarks/state.hs
+++ b/replicated-log/benchmarks/state.hs
@@ -263,7 +263,7 @@ time_ act = do
   act
   end <- liftIO $ getTime Monotonic
   let !delta = diffTimeSpec end start
-  return $ fromIntegral (timeSpecAsNanoSecs delta) / 10^(9 :: Int)
+  return $ fromIntegral $ toNanoSecs delta `div` 10^(9::Int)
 
 -- | Convert a number of seconds to a string.  The string will consist
 -- of four decimal places, followed by a short description of the time


### PR DESCRIPTION
*Created by: andriytk*

Use toNanoSecs instead.