### PR TITLE
Drop duplicate log about clovis processes start

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Node/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Node/Rules.hs
@@ -782,8 +782,6 @@ ruleStartProcessesOnNode = mkJobRule processStartProcessesOnNode args $ \(JobHan
       modify Local $ rlens fldRep .~
         Field (Just $ NodeProcessesStarted m0node)
       ps <- startProcesses host clovisProcess
-      Log.rcLog' Log.DEBUG $ "Starting these clovis processes: "
-                          ++ show (M0.showFid <$> ps)
       modify Local $ rlens fldWaitingProcs . rfield %~ (ps ++)
       continue clients_result
 


### PR DESCRIPTION
*Created by: andriytk*

The same log goes from `startProcesses` routine:

    §DEBUG processes => ["Process{0x7200000000000001:0xe5}","Process{0x7200000000000001:0xc5}",...
    §DEBUG Starting these clovis processes: ["Process{0x7200000000000001:0xe5}",...

On big configurations, like 120+ processes it just spams the log.