### PR TITLE
stack.yaml: add rebuild-ghc-options: true

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -47,6 +47,7 @@ ghc-options:
   #
   # TODO: Find the root cause of the problem.
   distributed-process: -O0
+rebuild-ghc-options: true
 
 docker:
   enable: false


### PR DESCRIPTION
*Created by: andriytk*

This will recompile local (by default) modules automatically when some ghc-option is changed in cmdline.