### PR TITLE
Adding In Storage Compute Service (ISCS)

### DIFF
--- a/confc/Mero/Conf/Obj.hsc
+++ b/confc/Mero/Conf/Obj.hsc
@@ -55,6 +55,7 @@ data {-# CTYPE "conf/schema.h" "struct m0_conf_service_type" #-} ServiceType
     | CST_BE      -- ^ BE service
     | CST_M0T1FS  -- ^ m0t1fs service
     | CST_CLOVIS  -- ^ Clovis service
+    | CST_ISCS    -- ^ ISC service
     | CST_UNKNOWN Int
   deriving (Data, Eq, Generic, Ord, Read, Show)
 
@@ -84,6 +85,7 @@ instance Enum ServiceType where
   toEnum #{const M0_CST_BE}      = CST_BE
   toEnum #{const M0_CST_M0T1FS}  = CST_M0T1FS
   toEnum #{const M0_CST_CLOVIS}  = CST_CLOVIS
+  toEnum #{const M0_CST_ISCS}    = CST_ISCS
   toEnum i                       = CST_UNKNOWN i
 
   fromEnum CST_MDS         = #{const M0_CST_MDS}
@@ -106,6 +108,7 @@ instance Enum ServiceType where
   fromEnum CST_BE          = #{const M0_CST_BE}
   fromEnum CST_M0T1FS      = #{const M0_CST_M0T1FS}
   fromEnum CST_CLOVIS      = #{const M0_CST_CLOVIS}
+  fromEnum CST_ISCS        = #{const M0_CST_ISCS}
   fromEnum (CST_UNKNOWN i) = i
 
 deriveSafeCopy 0 'base ''ServiceType

--- a/mero-halon/scripts/mero_clovis_role_mappings.ede
+++ b/mero-halon/scripts/mero_clovis_role_mappings.ede
@@ -110,6 +110,10 @@
             tag: CST_CAS
             contents: []
           m0s_endpoints: ["{{ lnid }}:12345:41:401"]
+        - m0s_type:
+            tag: CST_ISCS
+            contents: []
+          m0s_endpoints: ["{{ lnid }}:12345:41:401"]
 - name: "m0t1fs"
   content:
     - m0p_endpoint: "{{ lnid }}:12345:41:301"

--- a/mero-halon/scripts/mero_provisioner_role_mappings.ede
+++ b/mero-halon/scripts/mero_provisioner_role_mappings.ede
@@ -106,6 +106,10 @@
             tag: CST_ADDB2
             contents: []
           m0s_endpoints: ["{{ lnid }}:12345:41:401"]
+        - m0s_type:
+            tag: CST_ISCS
+            contents: []
+          m0s_endpoints: ["{{ lnid }}:12345:41:401"]
 - name: "m0t1fs"
   content:
     - m0p_endpoint: "{{ lnid }}:12345:41:301"

--- a/mero-halon/scripts/mero_s3server_role_mappings.ede
+++ b/mero-halon/scripts/mero_s3server_role_mappings.ede
@@ -110,6 +110,10 @@
             tag: CST_CAS
             contents: []
           m0s_endpoints: ["{{ lnid }}:12345:41:401"]
+        - m0s_type:
+            tag: CST_ISCS
+            contents: []
+          m0s_endpoints: ["{{ lnid }}:12345:41:401"]
 - name: "m0t1fs"
   content:
     - m0p_endpoint: "{{ lnid }}:12345:41:301"

--- a/mero-halon/tests/Helper/InitialData.hs
+++ b/mero-halon/tests/Helper/InitialData.hs
@@ -285,6 +285,7 @@ iosProcess ifaddr = CI.M0Process
                                    , CST_IOS
                                    , CST_SNS_REP
                                    , CST_SNS_REB
+                                   , CST_ISCS
                                    , CST_ADDB2
                                    ]
   , CI.m0p_environment = Nothing


### PR DESCRIPTION
*Created by: nsahasra-seagate*

-In storage compute service enables function shipping, a feature in Mero
 that allows a third party code to run using Mero internals.
-This patch ensures that Halon generates a configuration that would have
 ISCS present.
-The changes are associated with following change id in Mero:
 Change-Id: I0602cebd8f6adf99da1da79d6b9e13e5cba13ad1