### PR TITLE
HALON-830: fix intermittent fork-remove-messages UT failures

### DIFF
--- a/cep/cep/tests/Regression.hs
+++ b/cep/cep/tests/Regression.hs
@@ -44,14 +44,8 @@ testFork = do
     usend pid ()
     usend pid (5::Int)
 
-    assertEqual "foo"
-      [ "load"
-      , "work1"
-      , "load"
-      , "work3"
-      , "load"
-      , "work5"
-      ] =<< replicateM 6 expect
+    assertEqual "foo" [ "work1", "work3", "work5" ]
+      . filter (/= "load") =<< replicateM 6 expect
   where
 
     rule :: ProcessId -> Specification TestApp ()


### PR DESCRIPTION
*Created by: andriytk*

In this test 3 SM instances are started one after another
through their phases.  Sometimes the next SM instance
starts working before the previous one is finished yet,
causing the resulting output to be overlapped. This effect
seems to be harmless, because within the single SM instance
the messages are still handled in right order.

So we just fix the test by excluding the check for the
1st SM phase output.