### PR TITLE
ruleNotificationHandler: fix eid leak

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Service/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Service/Rules.hs
@@ -77,7 +77,6 @@ ruleNotificationHandler = define "castor::service::notification-handler" $ do
         else Nothing
 
   setPhaseIfConsume start_rule startOrStop $ \(eid, service, st, typ) -> do
-    todo eid
     Log.tagContext Log.SM service Nothing
     Log.tagContext Log.SM [
         ("transaction.id", show eid)


### PR DESCRIPTION
*Created by: andriytk*

setPhaseIfConsume automatically takes the reference for eid,
so there is no need to take it again at start_rule phase.