### PR TITLE
Fix `hctl halon info eq`

### DIFF
--- a/halon/src/lib/HA/EventQueue.hs
+++ b/halon/src/lib/HA/EventQueue.hs
@@ -36,13 +36,12 @@ module HA.EventQueue
   , EQStatResp(..)
   , PoolStats(..)
   , requestEQStats
-  , runtimeInfoRequest
   ) where
 
 import Control.Distributed.Process
   ( NodeId
-  , getSelfPid
   , Process
+  , getSelfPid
   , nsendRemote
   )
 import HA.EventQueue.Producer
@@ -52,12 +51,5 @@ import HA.EventQueue.Types
 -- after it was called 'EQStatResp' will be send to the process's mailbox.
 requestEQStats :: NodeId -> Process ()
 requestEQStats eq = do
-  self <- getSelfPid
-  nsendRemote eq eventQueueLabel $ EQStatReq self
-
--- | Request EventQueue statistics. This method is asynchronous,
--- after it was called 'EQStatResp' will be send to the process's mailbox.
-runtimeInfoRequest :: NodeId -> Process ()
-runtimeInfoRequest eq = do
   self <- getSelfPid
   nsendRemote eq eventQueueLabel $ EQStatReq self


### PR DESCRIPTION
*Created by: vvv*

`hctl halon info eq --cep` didn't work properly: it hung, expecting `RuntimeInfo`, which never arrived. The implementation of `runtimeInfoRequest`, being a copy-n-pasted replica of `requestEQStats`, was sending wrong type of request (`EQStatReq` instead of `RuntimeInfoRequest`).

- Delete `runtimeInfoRequest`.
- Delete `--cep` and `--memory` options of `hctl halon info eq`. `--memory` was a noop, and `--cep` is covered by dedicated `hctl halon info cep` command.