### PR TITLE
Restore previously overwritten copyright years

### DIFF
--- a/confc/Mero/Conf/Context.hsc
+++ b/confc/Mero/Conf/Context.hsc
@@ -8,7 +8,7 @@
 {-# LANGUAGE TemplateHaskell            #-}
 
 -- |
--- Copyright : (C) 2018 Xyratex Technology Limited.
+-- Copyright : (C) 2015-2018 Xyratex Technology Limited.
 -- License   : All rights reserved.
 --
 -- inline-c context for the conf interface.

--- a/confc/Mero/Conf/Fid.hsc
+++ b/confc/Mero/Conf/Fid.hsc
@@ -6,7 +6,7 @@
 {-# LANGUAGE MultiWayIf               #-}
 {-# LANGUAGE TupleSections            #-}
 -- |
--- Copyright : (C) 2018 Xyratex Technology Limited.
+-- Copyright : (C) 2015-2018 Xyratex Technology Limited.
 -- License   : All rights reserved.
 --
 -- Mero identifier type. Mero uses FIDs to uniquely identity most objects

--- a/confc/Mero/Conf/Obj.hsc
+++ b/confc/Mero/Conf/Obj.hsc
@@ -8,7 +8,7 @@
 {-# LANGUAGE TupleSections            #-}
 
 -- |
--- Copyright : (C) 2018 Xyratex Technology Limited.
+-- Copyright : (C) 2015-2018 Xyratex Technology Limited.
 -- License   : All rights reserved.
 --
 -- Bindings to the confc client library. confc allows programs to

--- a/confc/Mero/ConfC.hs
+++ b/confc/Mero/ConfC.hs
@@ -1,5 +1,5 @@
 -- |
--- Copyright : (C) 2018 Xyratex Technology Limited.
+-- Copyright : (C) 2013-2018 Xyratex Technology Limited.
 -- License   : All rights reserved.
 --
 module Mero.ConfC

--- a/confc/Mero/Spiel.hs
+++ b/confc/Mero/Spiel.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 
 -- |
--- Copyright : (C) 2018 Xyratex Technology Limited.
+-- Copyright : (C) 2015-2018 Xyratex Technology Limited.
 -- License   : All rights reserved.
 --
 -- Bindings to the spiel interface.

--- a/confc/Mero/Spiel/Context.hsc
+++ b/confc/Mero/Spiel/Context.hsc
@@ -5,7 +5,7 @@
 {-# LANGUAGE TemplateHaskell   #-}
 
 -- |
--- Copyright : (C) 2018 Xyratex Technology Limited.
+-- Copyright : (C) 2015-2018 Xyratex Technology Limited.
 -- License   : All rights reserved.
 --
 -- inline-c context for the spiel interface.

--- a/confc/Mero/Spiel/Internal.hsc
+++ b/confc/Mero/Spiel/Internal.hsc
@@ -5,7 +5,7 @@
 {-# LANGUAGE TemplateHaskell          #-}
 
 -- |
--- Copyright : (C) 2018 Xyratex Technology Limited.
+-- Copyright : (C) 2015-2018 Xyratex Technology Limited.
 -- License   : All rights reserved.
 --
 -- Bindings to the spiel interface.

--- a/confc/confc.cabal
+++ b/confc/confc.cabal
@@ -4,7 +4,7 @@ Synopsis:      Bindings for Mero configuration client library.
 Description:   The Mero configuration client library allows programs
                to contact the confd service.
 License:       AllRightsReserved
-Copyright:     (C) 2018 Xyratex Technology Limited
+Copyright:     (C) 2013-2018 Xyratex Technology Limited
 Category:      Network
 Build-Type:    Custom
 Cabal-Version: >= 1.10

--- a/confc/confc_helpers.c
+++ b/confc/confc_helpers.c
@@ -1,5 +1,5 @@
 //
-// Copyright : (C) 2018 Xyratex Technology Limited.
+// Copyright : (C) 2013-2018 Xyratex Technology Limited.
 // License   : All rights reserved.
 //
 

--- a/confc/confc_helpers.h
+++ b/confc/confc_helpers.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2018 Xyratex Technology Limited. All rights reserved.
+// Copyright (C) 2013-2018 Xyratex Technology Limited. All rights reserved.
 //
 // See the accompanying COPYING file for license information.
 //

--- a/halon/src/lib/HA/Debug.hs
+++ b/halon/src/lib/HA/Debug.hs
@@ -1,5 +1,5 @@
 -- |
--- Copyright: (C) 2018 Xyratex Technology Limited
+-- Copyright: (C) 2016-2018 Xyratex Technology Limited
 -- License:   All rights reserved
 --
 -- Debug functions that make use of eventlog subsystem.

--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -7,7 +7,7 @@ Description:    The High Availability system is a library that can be used
                 high availability of a distributed application.
 Homepage:       https://github.com/tweag/halon
 License:        AllRightsReserved
-Copyright:      (C) 2018 Xyratex Technology Limited
+Copyright:      (C) 2013-2018 Xyratex Technology Limited
 Category:       Control
 Build-Type:     Simple
 Cabal-Version:  >=1.10

--- a/mero-halon/src/halonctl/Main.hs
+++ b/mero-halon/src/halonctl/Main.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE RecordWildCards #-}
 -- |
--- Copyright : (C) 2018 Seagate Technology Limited.
+-- Copyright : (C) 2013-2018 Seagate Technology Limited.
 -- License   : All rights reserved.
 module Main (main) where
 

--- a/mero-halon/src/halonctl/Options/Applicative/Extras.hs
+++ b/mero-halon/src/halonctl/Options/Applicative/Extras.hs
@@ -1,5 +1,5 @@
 -- |
--- Copyright : (C) 2018 Xyratex Technology Limited.
+-- Copyright : (C) 2014-2018 Xyratex Technology Limited.
 -- License   : All rights reserved.
 --
 

--- a/rpclite/rpclite/m0init.c
+++ b/rpclite/rpclite/m0init.c
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2018 Xyratex Technology Limited. All rights reserved.
+// Copyright (C) 2015-2018 Xyratex Technology Limited. All rights reserved.
 //
 
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_HA

--- a/rpclite/rpclite/m0init.h
+++ b/rpclite/rpclite/m0init.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2018 Xyratex Technology Limited. All rights reserved.
+// Copyright (C) 2015-2018 Xyratex Technology Limited. All rights reserved.
 //
 #pragma once
 #ifndef __H0_M0INIT_H__


### PR DESCRIPTION
*Created by: vvv*

Use year ranges.

[[https://stackoverflow.com/a/2391555/136238]](https://stackoverflow.com/a/2391555/136238):

> The copyright notice on a work establishes a claim to copyright. The
> date on the notice establishes how far back the claim is made. This
> means if you update the date, you are no longer claiming the copyright
> for the original date and that means if somebody has copied the work
> in the meantime and they claim its theirs on the ground that their
> publishing the copy was before your claim, then it will be difficult
> to establish who is the originator of the work.
>
> Therefore, if the claim is based on common law copyright (not formally
> registered), then the date should be the date of first publication. If
> the claim is a registered copyright, then the date should be the date
> claimed in the registration. In cases where the work was substantially
> revised you may establish a new copyright claim to the revised work by
> adding another copyright notice with a newer date or by adding an
> additional date to the existing notice as in "© 2000, 2010". Again,
> the added date establishes how far back the claim is made on the
> revision.

Thanks to @andriytk  for pointing this out!