### PR TITLE
scripts/h0: Default to `--fast` compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,7 @@ templates:
               done
       - run:
           name: Installing latest Mero master rpms
-          command: |
-              yum install -y ~/rpmbuild/RPMS/x86_64/mero-*.rpm
+          command: yum install -y ~/rpmbuild/RPMS/x86_64/mero-*.rpm
       - run:
           name: Building Halon rpms
           working_directory: ~/halon
@@ -161,7 +160,9 @@ jobs:
           #   Logs have been written to: /root/halon/.stack-work/logs/regex-tdfa-1.2.2.log
           #
           # TODO: investigate the root cause and implement a proper solution
-          command: ./scripts/h0 make || ./scripts/h0 make
+          command: |
+            export GHC_OPTS='-g -j2'
+            ./scripts/h0 make || ./scripts/h0 make
 
       - persist_to_workspace:
           root: /root
@@ -178,7 +179,7 @@ jobs:
           name: Running Halon unit tests
           working_directory: ~/halon
           no_output_timeout: 30m
-          command: ./scripts/h0 test
+          command: GHC_OPTS='-g -j2' ./scripts/h0 test
 
   rpmbuild:
     <<: *docker-image-latest

--- a/scripts/h0
+++ b/scripts/h0
@@ -17,11 +17,22 @@ warn() { echo "*WARNING* $@" >&2; }
 
 H0_SRC_DIR="$(readlink -f $0)"
 H0_SRC_DIR="${H0_SRC_DIR%/*/*}"
+DEFAULT_M0_SRC_DIR=${H0_SRC_DIR%/*}/mero
+
+## By default, optimizations are turned off (-O0) to reduce compilation time.
+## Users can enable optimizations by setting GHC_OPTS environment variable
+## explicitly, e.g.,
+##
+##     GHC_OPTS='-g -j2' ./scripts/h0 rebuild
+##
+## NB: `stack build --fast` is equivalent to `stack build --ghc-options=-O0`.
+DEFAULT_GHC_OPTS='-g -j2 -O0'
 
 ## -------------------------------------------------------------------
 ## Configurable section
 
-export M0_SRC_DIR=${M0_SRC_DIR:-${H0_SRC_DIR%/*}/mero}
+export M0_SRC_DIR=${M0_SRC_DIR:-$DEFAULT_M0_SRC_DIR}
+GHC_OPTS=${GHC_OPTS:-$DEFAULT_GHC_OPTS}
 ## -------------------------------------------------------------------
 
 PROG="${0##*/}"
@@ -57,7 +68,7 @@ _stack_build() {
             --extra-include-dirs="$M0_SRC_DIR" \
             --extra-lib-dirs="$M0_SRC_DIR/mero/.libs" \
             build \
-                --ghc-options="${GHC_OPTS:--g -j2}" \
+                --ghc-options="$GHC_OPTS" \
                 "$@"
 }
 
@@ -194,7 +205,9 @@ Options:
     Stack.  Type \`stack <command> --help' for documentation.
 
 Environment variables:
-    M0_SRC_DIR    Path to Mero sources directory; defaults to '$M0_SRC_DIR'.
+    M0_SRC_DIR  Path to Mero sources directory; defaults to
+                '$DEFAULT_M0_SRC_DIR'.
+    GHC_OPTS    Extra options for ghc; defaults to '$DEFAULT_GHC_OPTS'.
 
 Examples:
 


### PR DESCRIPTION
*Created by: vvv*

- `--fast` turns off optimizations, reducing compilation time. Defaulting to `--fast` is justified, because `h0` script is mostly used during edit-compile-debug cycle.
- Fix the default value of M0_SRC_DIR printed by `h0 help`.
