### PR TITLE
HALON-836: set DIXInitialised in mkfs-done startup mode

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Rules.hs
@@ -222,6 +222,7 @@ ruleMarkProcessesBootstrapped = defineSimpleTask "castor::server::mark-all-proce
      modifyGraph . execState $ do
        for_ (M0.getM0Processes rg) $ \proc ->
          State.modify (G.connect proc R.Is M0.ProcessBootstrapped)
+     modifyGraph $ G.connect (M0.getM0Root rg) Has M0.DIXInitialised
      registerSyncGraph $ do
        sendChan ch ()
 


### PR DESCRIPTION
*Created by: andriytk*

DIX initialisation should be skipped along with m0mkfs
when cluster is started in mkfs-done mode.