### PR TITLE
HALON-849: fix checkDiskFailureWithinTolerance

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Drive/Actions.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Drive/Actions.hs
@@ -271,7 +271,7 @@ checkDiskFailureWithinTolerance sdev st rg = case mk of
                            ]
          in case mapMaybe getK pvers of
               [] -> Nothing
-              xs -> Just (fromIntegral $ maximum xs, length failedDisks)
+              xs -> Just (fromIntegral $ minimum xs, length failedDisks)
 
 -- | Install storage device into the slot.
 updateStorageDevicePresence :: UUID          -- ^ Thread id.


### PR DESCRIPTION
*Created by: andriytk*

checkDiskFailureWithinTolerance could return false-positive
result on multiple pools. If some failed disk belongs to
different pools with different Ks, it would check the pool
which has maximum K only. But it may well be that the
failed disk is not tolerable already in another pool(s)
with lesser K.

Now we check the pool with has minimum K in the list.
If we can tolerate disk failure in it - we can tolerate
it in all the others that has the same or bigger K.