### PR TITLE
Optimize Disk-Replaced relation in RG

### DIFF
--- a/mero-halon/src/lib/HA/Resources/Mero.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero.hs
@@ -1100,7 +1100,7 @@ $(mkResRel
   , (''SDev, Unbounded, ''Cas.Is, AtMostOne, ''SDevState)
   , (''Node, Unbounded, ''Cas.Is, AtMostOne, ''NodeState)
   , (''Controller, Unbounded, ''Cas.Is, AtMostOne, ''ControllerState)
-  , (''Disk, AtMostOne, ''Cas.Is, AtMostOne, ''Replaced)
+  , (''Disk, Unbounded, ''Cas.Is, AtMostOne, ''Replaced)
   , (''Root, AtMostOne, ''R.Has, AtMostOne, ''FilesystemStats)
   , (''Root, AtMostOne, ''R.Has, AtMostOne, ''DIXInitialised)
   ]


### PR DESCRIPTION
*Created by: andriytk*

Several disks can be replaced, so the relation should be
many to one: many disks to one replaced attribute.