### PR TITLE
halonctl: Improve cluster disposition output

### DIFF
--- a/mero-halon/src/halonctl/Handler/Mero/Status.hs
+++ b/mero-halon/src/halonctl/Handler/Mero/Status.hs
@@ -64,7 +64,7 @@ jsonReport = BSL.putStrLn . HA.Aeson.encode
 
 prettyReport :: Bool -> ReportClusterState -> IO ()
 prettyReport showDevices ReportClusterState{..} = do
-  putStrLn $ "Cluster is " ++ maybe "N/A" (show . M0._mcs_disposition) csrStatus
+  putStrLn $ "Cluster disposition: " ++ maybe "N/A" (show . M0._mcs_disposition) csrStatus
   case csrProfile of
     Nothing -> putStrLn "Cluster information is not available, load initial data first."
     Just prof -> do


### PR DESCRIPTION
*Created by: vvv*

"Cluster is ONLINE" line of `hctl mero status` output was pretty
misleading, especially in situations when there were lots of failed
nodes.  Change that line to "Cluster disposition: ONLINE", for it's
cluster disposition - i.e., the desired state of the cluster -
what is actually being shown.