### PR TITLE
st/t_sns-rep-reb: print drive states after each wait

### DIFF
--- a/st/t_sns-rep-reb
+++ b/st/t_sns-rep-reb
@@ -18,6 +18,8 @@ expect_state() (
             break
         fi
     done
+    set -x
+    hctl mero status -d
 )
 
 $H0 start


### PR DESCRIPTION
*Created by: max-seagate*

