### PR TITLE
HALON-823: fix sporadic notification failures

### DIFF
--- a/mero-halon/src/lib/Mero/Notification.hs
+++ b/mero-halon/src/lib/Mero/Notification.hs
@@ -478,7 +478,8 @@ initializeHAStateCallbacks lnode addr processFid haFid rmFid fbarrier fdone = do
 
     ha_connected :: NIRef -> HA.ReqId -> HA.HALink -> IO ()
     ha_connected ni req hl = do
-      mfid <- atomicModifyIORef' (_ni_requests ni) $ \x -> (Map.delete req x, Map.lookup req x)
+      mfid <- atomicModifyIORef' (_ni_requests ni) $
+        \x -> (Map.delete req x, Map.lookup req x)
       for_ mfid $ \fid -> do
         currentTime <- getTime Monotonic
         atomicModifyIORef' (_ni_last_seen ni) $ \x -> (Map.insert hl currentTime x, ())
@@ -490,8 +491,9 @@ initializeHAStateCallbacks lnode addr processFid haFid rmFid fbarrier fdone = do
     ha_reused :: NIRef -> HA.ReqId -> HA.HALink -> IO ()
     ha_reused ni ri hl = do
        mfid <- atomicModifyIORef' (_ni_requests  ni) $
-         swap . Map.updateLookupWithKey (const $ const $ Nothing) ri
-       for_ mfid $ \_ -> do
+         swap . Map.updateLookupWithKey (const $ const Nothing) ri
+       for_ mfid $ \fid -> do
+         log $ "ha_reused: link=" ++ show hl ++ " fid=" ++ show fid
          currentTime <- getTime Monotonic
          atomicModifyIORef' (_ni_last_seen ni) $ \x -> (Map.insert hl currentTime x, ())
 

--- a/mero-halon/src/lib/Mero/Notification/HAState.hsc
+++ b/mero-halon/src/lib/Mero/Notification/HAState.hsc
@@ -357,7 +357,7 @@ initHAState (RPCAddress rpcAddr) procFid haFid rmFid hsc
       wmsgcallback <- wrapGenericCallback
       #{poke ha_state_callbacks_t, ha_state_entrypoint} pcbs wentry
       #{poke ha_state_callbacks_t, ha_state_link_connected} pcbs wconnected
-      #{poke ha_state_callbacks_t, ha_state_link_reused} pcbs wconnected
+      #{poke ha_state_callbacks_t, ha_state_link_reused} pcbs wreused
       #{poke ha_state_callbacks_t, ha_state_link_disconnecting} pcbs
          wdisconnecting
       #{poke ha_state_callbacks_t, ha_state_link_disconnected} pcbs


### PR DESCRIPTION
*Created by: andriytk*

The problem was in ha_connect handler where the all the
link's pending notification delivery tags were flushed
out. If ha_connect would come between notification sending
and delivery callback, such notification would never be
confirmed to be delivered and hence would fail.