### PR TITLE
Network.CEP.Types (startForks): Delete noisy prefixes

### DIFF
--- a/cep/cep/src/Network/CEP/Types.hs
+++ b/cep/cep/src/Network/CEP/Types.hs
@@ -464,10 +464,10 @@ startForks rules state = do
       wrapper_clear <- phaseHandle "wrapper_clear"
       wrapper_end <- phaseHandle "wrapper_end"
 
-      directly wrapper_init $ Network.CEP.Types.switch (rules ++ [wrapper_clear])
+      directly wrapper_init $ switch (rules ++ [wrapper_clear])
 
       directly wrapper_clear $ do
-        fork NoBuffer $ Network.CEP.Types.switch (rules++[timeout 60 wrapper_clear])
+        fork NoBuffer $ switch (rules ++ [timeout 60 wrapper_clear])
         continue wrapper_end
 
       directly wrapper_end stop


### PR DESCRIPTION
*Created by: vvv*

