### PR TITLE
hctl (parseSNSOpts): Fix help message

### DIFF
--- a/mero-halon/src/halonctl/Handler/Mero/Pool.hs
+++ b/mero-halon/src/halonctl/Handler/Mero/Pool.hs
@@ -84,7 +84,7 @@ parseSNSOpts = SNSOpts
   <*> Opt.option (Opt.maybeReader UUID.fromString)
       ( Opt.long "uuid"
       <> Opt.short 'u'
-      <> Opt.help "UUID of the pool operation. Shown in `hctl cluster status`"
+      <> Opt.help "UUID of the pool operation. Shown in `hctl mero status`."
       <> Opt.metavar "UUID"
       )
   <*> Opt.option Opt.auto

--- a/st/t_sns-rep-reb
+++ b/st/t_sns-rep-reb
@@ -9,10 +9,12 @@ $H0 start
 # XXX Use c0cp instead of dd (i.e., clovis instead of m0t1fs).
 $SUDO dd if=/dev/zero of=/mnt/m0t1fs/fedcba98:76543210 bs=32k count=100
 
+# "Fail" a drive.
 hctl mero drive update-presence $DRIVE_SELECT_OPTS
 wait_for_state 'SDSRepaired' $SERIAL
 
 hctl mero vars set --disable-smart-check True
+# "Replace" the drive.
 hctl mero drive update-presence $DRIVE_SELECT_OPTS --is-powered --is-installed
 hctl mero drive update-status $DRIVE_SELECT_OPTS --status OK
 wait_for_state 'SDSOnline' $SERIAL

--- a/st/t_stop-reverts-sdev-states
+++ b/st/t_stop-reverts-sdev-states
@@ -6,15 +6,16 @@ DRIVE_SELECT_OPTS="--slot-enclosure ENC#0 --serial $SERIAL --slot-index 2"
 
 $H0 start
 
-# XXX Use c0cp instead of dd (i.e., clovis instead of m0t1fs).
 FID='fedcba98:76543210'
 $SUDO touch /mnt/m0t1fs/$FID
 # Set unit size to 1M in order for `dd` to complete sooner.
 # See m0_lid_to_unit_map[] for supported `lid` values.
 $SUDO setfattr -n lid -v 9 /mnt/m0t1fs/$FID
 # Big enough file will still be under repair when SNS_REP is terminated.
+# XXX Use c0cp instead of dd (i.e., clovis instead of m0t1fs).
 $SUDO dd if=/dev/zero of=/mnt/m0t1fs/$FID bs=8M count=200
 
+# "Fail" a drive.
 hctl mero drive update-presence $DRIVE_SELECT_OPTS
 wait_for_state 'SDSRepairing' $SERIAL
 


### PR DESCRIPTION
*Created by: vvv*

Fix documentation of `--uuid` parameter of `hctl mero pool repreb` command.

+ st: Minor documentation edits.