### PR TITLE
ruleDebug{Query,Modify}: Use more descriptive names

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Rules/Debug.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/RC/Rules/Debug.hs
@@ -36,7 +36,7 @@ debugRules = sequence_
 
 -- | Dispatches `hctl debug print` requests.
 ruleDebugQuery :: Definitions RC ()
-ruleDebugQuery = defineSimpleTask "debug-query" $ \case
+ruleDebugQuery = defineSimpleTask "hctl-debug-query" $ \case
     D.DebugQueryDriveInfo req -> queryDriveInfo req
 
 -- | Handles `hctl debug print drive` requests.
@@ -83,7 +83,7 @@ getDebugDriveInfo rg sd =
 
 -- | Dispatches `hctl debug set` requests.
 ruleDebugModify :: Definitions RC ()
-ruleDebugModify = defineSimpleTask "debug-modify" $ \case
+ruleDebugModify = defineSimpleTask "hctl-debug-modify" $ \case
     D.DebugModifyDriveState req -> modifyDriveState req
     D.DebugModifySdevState req -> modifySdevState req
 

--- a/mero-halon/src/lib/HA/Resources/Mero.hs
+++ b/mero-halon/src/lib/HA/Resources/Mero.hs
@@ -711,7 +711,7 @@ deriveSafeCopy 0 'base ''PoolRepairInformation_v0
 data PoolRepairInformation = PoolRepairInformation
   { priTimeOfSnsStart :: !TimeSpec
   , priTimeLastHourlyRan :: !TimeSpec
-  , priStateUpdates :: ![(SDev, Int)]
+  , priStateUpdates :: ![(SDev, Int)]  -- XXX TODO: Replace Int with a meaningful type.
   } deriving (Eq, Show, Generic, Typeable, Ord)
 
 instance Hashable PoolRepairInformation


### PR DESCRIPTION
*Created by: vvv*

Rule name is written to the decision log. Make it clear that it is `halonctl` command being processed.