### PR TITLE
Change 'Docs' string in output of systemctl status halond

### DIFF
--- a/systemd/halond.service
+++ b/systemd/halond.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Halon Daemon
-Documentation=https://github.com/tweag/halon
+Documentation=https://github.com/seagate-ssg/halon
 Wants=rabbitmq-server.service 
 After=network.target rabbitmq-server.service
 


### PR DESCRIPTION
Updated 'Documentation' string in file halond.service to
https://github.com/seagate-ssg/halon