### PR TITLE
scripts/install-halon-services: use eth1 for HALOND_LISTEN

### DIFF
--- a/scripts/install-halon-services
+++ b/scripts/install-halon-services
@@ -158,7 +158,7 @@ install_files()
     run "cp ${v} -f $H0_SRC_DIR/systemd/sysconfig/halon-satellite $dir"
     # example output of `ip address` command that is parsed below
     #   3: eth1    inet 172.28.128.94/24 brd 172.28.128.255 scope global dynamic eth1...
-    local ip_addr=$(ip -oneline -4 address show scope global up | grep -v docker | tail -n 1 |
+    local ip_addr=$(ip -oneline -4 address show eth1 |
                     awk '{print $4}' | cut -d/ -f1)
     run "sed -i -r s/^#(HALOND_LISTEN=).*(:[[:digit:]]+)$/\1${ip_addr}\2/ $dir/halond"
 


### PR DESCRIPTION
If cmu has several interfaces - the old code would pick up
only the last one and take its IP address for the HALON_LISTEN
parameter. But on the vagrant setup, for example, this might
be the bridge interface and the wrong one.

Now we always take eth1 - the same way when we generate the
facts file from scripts/h0.