### PR TITLE
HALON-889: network-transport update

### DIFF
--- a/cep/cep/tests/UnitTests.hs
+++ b/cep/cep/tests/UnitTests.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TupleSections #-}
+
 module Main where
 
 import Control.Exception
@@ -17,8 +19,9 @@ import System.Timeout
 
 ut :: IO TestTree
 ut = do
-    t <- either throwIO return =<<
-         createTransport "127.0.0.1" "4000" defaultTCPParameters
+    t <- either throwIO return =<< do
+         let h = "127.0.0.1"
+         createTransport h "4000" (h,) defaultTCPParameters
 
     let launch action =
           (>>= maybe (error "Timeout") return) $ timeout 10000000 $

--- a/consensus-paxos/tests/Test.hs
+++ b/consensus-paxos/tests/Test.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections   #-}
+
 module Test (tests) where
 
 import Prelude hiding ((<$>))
@@ -77,8 +79,8 @@ proposeWrapper αs d x = (x ==) <$>
 
 tests :: IO TestTree
 tests = do
-    Right transport <- createTransport "127.0.0.1" "0" defaultTCPParameters
-
+    let h = "127.0.0.1"
+    Right transport <- createTransport h "0" (h,) defaultTCPParameters
     return $ testGroup "consensus-paxos"
       [ testSuccess "single-decree" $ setup transport 1 $ \them -> do
             assert =<< proposeWrapper them (DecreeId 0 0) 42

--- a/halon/tests/Test/Transport.hs
+++ b/halon/tests/Test/Transport.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE CPP           #-}
+{-# LANGUAGE TupleSections #-}
 -- |
 -- Copyright: (C) 2015 Seagate Technology Limited.
 --
-{-# LANGUAGE CPP #-}
+
 module Test.Transport
   ( AbstractTransport(..)
   , mkTCPTransport
@@ -45,7 +47,9 @@ mkControlledTransport transport = Controlled.createTransport (getTransport trans
 
 mkTCPTransport :: IO AbstractTransport
 mkTCPTransport = do
-    Right (transport, internals) <- TCP.createTransportExposeInternals "127.0.0.1" "0" TCP.defaultTCPParameters
+    let h = "127.0.0.1"
+    Right (transport, internals) <- TCP.createTransportExposeInternals h "0" (h,)
+                                                       TCP.defaultTCPParameters
     let -- XXX: Could use enclosed-exceptions here. Note that the worker
         -- is not killed in case of an exception.
         ignoreSyncExceptions action = do

--- a/mero-halon/src/halonctl/Lookup.hs
+++ b/mero-halon/src/halonctl/Lookup.hs
@@ -7,11 +7,9 @@ module Lookup
   , findEQFromNodes
   ) where
 
-import qualified HA.EQTracker          as EQT
-
-import Control.Distributed.Process
-
-import qualified Network.Transport.TCP as TCP
+import           Control.Distributed.Process
+import qualified Network.Transport.TCP.Internal as TCP
+import qualified HA.EQTracker                   as EQT
 
 conjureRemoteNodeId :: String -> NodeId
 conjureRemoteNodeId addr =

--- a/mero-halon/src/halonctl/Main.hs
+++ b/mero-halon/src/halonctl/Main.hs
@@ -117,7 +117,7 @@ run :: Options -> IO ()
 run Options{..} =
   let (hostname, port) = breakAt ':' optOurAddress in
   bracket (either (error . show) id <$>
-               createTransport hostname port
+               createTransport hostname port (hostname,)
                defaultTCPParameters { tcpUserTimeout = Just 2000
                                     , tcpNoDelay = True
                                     , transportConnectTimeout = Just 2000000

--- a/mero-halon/src/halond/Main.hs
+++ b/mero-halon/src/halond/Main.hs
@@ -58,7 +58,7 @@ main = do
            "consensus-paxos replicated-log EQ EQ.producer MM RS RG call startup"
         let (hostname, _:port) = break (== ':') $ localEndpoint config
         transport <- either (error . show) id <$>
-                     TCP.createTransport hostname port TCP.defaultTCPParameters
+                     TCP.createTransport hostname port (hostname,) TCP.defaultTCPParameters
                        { tcpUserTimeout = Just 2000
                        , tcpNoDelay = True
                        , transportConnectTimeout = Just 2000000

--- a/mero-halon/tests/tests.hs
+++ b/mero-halon/tests/tests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TupleSections #-}
 -- |
 -- Copyright : (C) 2013 Xyratex Technology Limited.
 -- License   : All rights reserved.
@@ -67,9 +68,9 @@ main = do
   let addr0 = host0 ++ ":" ++ show p0
 
   let TCP.SockAddrInet port hostaddr = TCP.decodeSocketAddress addr0
-  hostname <- TCP.inet_ntoa hostaddr
+  host <- TCP.inet_ntoa hostaddr
   (transport, internals) <- either (error . show) id <$>
-               TCP.createTransportExposeInternals hostname (show port)
+               TCP.createTransportExposeInternals host (show port) (host,)
                  TCP.defaultTCPParameters
                    { TCP.tcpNoDelay = True
                    , TCP.tcpUserTimeout = Just 2000

--- a/mero-integration/src/test-stha-local/test-stha-local.hs
+++ b/mero-integration/src/test-stha-local/test-stha-local.hs
@@ -7,6 +7,7 @@
 --
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 
 import Control.Distributed.Commands.Process
   ( systemLocal
@@ -75,7 +76,7 @@ main =
     putStrLn $ "Changed directory to: " ++ testDir
 
     let m0 = "0.0.0.0"
-    Right nt <- createTransport m0 "4000" defaultTCPParameters
+    Right nt <- createTransport m0 "4000" (m0,) defaultTCPParameters
     n0 <- newLocalNode nt (__remoteTable initRemoteTable)
     let killHalond = E.catch (readProcess "pkill" [ "halond" ] "" >> return ())
                              (\e -> const (return ()) (e :: E.SomeException))

--- a/replicated-log/tests/Transport.hs
+++ b/replicated-log/tests/Transport.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TupleSections #-}
 -- |
 -- Copyright: (C) 2015 Seagate Technology Limited.
 --
@@ -23,7 +24,8 @@ data AbstractTransport = AbstractTransport
 
 mkTCPTransport :: IO AbstractTransport
 mkTCPTransport = do
-    Right (transport, internals) <- TCP.createTransportExposeInternals "127.0.0.1" "0" TCP.defaultTCPParameters
+    let h = "127.0.0.1"
+    Right (transport, internals) <- TCP.createTransportExposeInternals h "0" (h,) TCP.defaultTCPParameters
     let -- XXX: Could use enclosed-exceptions here. Note that the worker
         -- is not killed in case of an exception.
         ignoreSyncExceptions action = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -31,12 +31,14 @@ packages:
   extra-dep: true
 
 extra-deps:
-- distributed-static-0.3.8
+- aeson-schema-0.4.1.3
+- containers-0.5.10.2
 - distributed-process-0.7.4
 - distributed-process-extras-0.3.5
+- distributed-static-0.3.8
 - ghc-datasize-0.1.2
-- containers-0.5.10.2
-- aeson-schema-0.4.1.3
+- network-transport-0.5.2
+- network-transport-tcp-0.6.0
 
 ghc-options:
   # XXX `CEP.regression.fork-remove-messages` UT will fail unless


### PR DESCRIPTION
Update network-transport to the latest versions:

 - network-transport: 0.4.4 -> 0.5.2;
 - network-transport-tcp: 0.5.1 -> 0.6.0.

This is the 1st step towards the lts-11 update.