### PR TITLE
scripts/halon-cleanup: Add `--keep-logs' option

### DIFF
--- a/scripts/h0
+++ b/scripts/h0
@@ -253,7 +253,7 @@ cmd_uninstall() {
 }
 
 cmd_erase_data() {
-    mpdsh sudo systemctl start halon-cleanup || true
+    mpdsh sudo $H0_SRC_DIR/scripts/halon-cleanup --keep-logs || true
     mpdsh sudo systemctl start mero-cleanup || true
 
     # `/var/mero` directory cannot be deleted on Jenkins CI nodes,

--- a/scripts/halon-cleanup
+++ b/scripts/halon-cleanup
@@ -2,22 +2,44 @@
 set -eu -o pipefail
 # set -x
 
-(($(id -u) == 0)) || {
-    echo 'Must be run by superuser' >&2
-    exit 1
+PROG=${0##*/}
+CLEAN_LOGS=1
+
+usage() {
+    cat <<EOF
+Usage: $PROG [--keep-logs]
+Stop Halon processes, delete persisted data, trace and log files.
+
+Options:
+    --keep-logs   Preserve /var/log/halon.decision.log and
+                  /var/log/halon.trace.log files.
+    -h, --help    Show this help and exit.
+EOF
 }
 
-pids=$(pidof halond)
+die() { echo "$*" >&2; exit 1; }
+_kill() { killall -v -KILL "$@" 2>/dev/null || true; }
 
-killall -v -KILL halonctl
-systemctl status halond.service &>/dev/null &&
-    systemctl stop halond.service ||
-        killall -v -KILL halond
+case ${1:-} in
+    -h|--help) usage; exit 0;;
+    --keep-logs) CLEAN_LOGS=0;;
+    '') :;;
+    *) die "Invalid argument. Type \`$PROG --help' for usage.";;
+esac
 
-for pid in pids; do
-    rm -fv {,/var/lib/halon/}m0trace.$pid
-done
+(($(id -u) == 0)) || die 'Must be run by superuser'
+
+pids=$(pidof halond || true)
+
+_kill halonctl
+systemctl status halond &>/dev/null &&
+    systemctl stop halond ||
+        _kill halond
 
 rm -rfv /var/lib/halon/halon-persistence/
 
-rm -fv /var/log/halon.{decision,trace}.log
+for pid in $pids; do
+    rm -fv {,/var/lib/halon/}m0trace.$pid
+done
+
+((CLEAN_LOGS == 1)) && rm -fv /var/log/halon.{decision,trace}.log


### PR DESCRIPTION
[bugfix] scripts/halon-cleanup: Proceed even if `pidof` or `killall`
exit with non-zero code.

`h0 cmd_erase_data` (implicitly called by `h0 init` and `h0 fini`)
will not delete /var/log/halon.{decision,trace}.log files. This will
let GitLab CI collect decision log "artifact".