### PR TITLE
Problem: halon-cleanup returns 1 when called w/o `--keep-logs`

### DIFF
--- a/scripts/halon-cleanup
+++ b/scripts/halon-cleanup
@@ -42,4 +42,4 @@ for pid in $pids; do
     rm -fv {,/var/lib/halon/}m0trace.$pid
 done
 
-((CLEAN_LOGS == 1)) && rm -fv /var/log/halon.{decision,trace}.log
+((CLEAN_LOGS == 0)) || rm -fv /var/log/halon.{decision,trace}.log


### PR DESCRIPTION
Symptom:

```
$ h0 init
[...]
----- init -----
pdsh@cmu: client1: ssh exited with exit code 1
pdsh@cmu: ssu1: ssh exited with exit code 1
pdsh@cmu: ssu2: ssh exited with exit code 1
pdsh@cmu: cmu: ssh exited with exit code 1
--->  Generating Halon facts for a cluster
[...]
```

Solution: fix conditional expression