### PR TITLE
requestClusterStatus: don't use fromJust

### DIFF
--- a/halon/src/lib/HA/Resources.hs
+++ b/halon/src/lib/HA/Resources.hs
@@ -46,6 +46,9 @@ deriveSafeCopy 0 'base ''Cluster
 -- | A resource graph representation for nodes.
 --
 -- XXX Move to HA.Resources.Castor?
+--
+-- This corresponds to "R.Node" in the Resouce Graph schema
+-- visualization [doc/halon-rg-schema.html].
 newtype Node = Node NodeId
   deriving (Eq, Generic, Hashable, Ord, Show, Typeable, FromJSON, ToJSON)
 

--- a/mero-halon/src/halonctl/Handler/Mero/Status.hs
+++ b/mero-halon/src/halonctl/Handler/Mero/Status.hs
@@ -96,16 +96,17 @@ prettyReport showDevices nids ReportClusterState{..} = do
                putStrLn $ "          " ++ show sdev_fid ++ " -> " ++ sdev_path
       putStrLn "\nHosts:"
       forM_ csrHosts $ \( Castor.Host qfdn
-                        , ReportClusterHost mnode st nid isRC ps ) -> do
+                        , ReportClusterHost mnode st mnid isRC ps ) -> do
          let (nst, extSt) = M0.displayNodeState st
          printf node_pattern nst (maybe "" fidStr mnode) qfdn
          for_ extSt $ printf pattern_ext
          forM_ ps $ \( M0.Process{r_fid=rfid, r_endpoint=endpoint}
                      , ReportClusterProcess ptype proc_st srvs ) -> do
            let (pst, proc_extSt) = M0.displayProcessState proc_st
-               tsTag | ptype == " halon" && isRC = " (RC)"
-                     | ptype == " halon" && nid `elem` nids = " (TS)"
-                     | otherwise = "" :: String
+               tsTag | ptype /= " halon"         = "" :: String
+                     | isRC                      = " (RC)"
+                     | mnid `elem` map Just nids = " (TS)"
+                     | otherwise                 = ""
            printf proc_pattern pst
                                (show rfid)
                                (T.unpack . encodeEndpoint $ endpoint)

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Events.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Events.hs
@@ -173,14 +173,15 @@ data ReportClusterHost = ReportClusterHost
       -- ^ Associated 'M0.Node'.
       , crnNodeStatus :: M0.StateCarrier M0.Node
       -- ^ Halon state of 'crnNodeFid'.
-      , crnNID        :: NodeId
-      -- ^ Node nid.   XXX DOCUMENTME Which node?
-      , isRC          :: Bool
+      , crnNodeId     :: Maybe NodeId
+      -- ^ NodeId of the associated 'HA.Resources.Node'.
+      , crnIsRC       :: Bool
       -- ^ Is this host running RC?
       , crnProcesses  :: [(M0.Process, ReportClusterProcess)]
       -- ^ Information about processes on the cluster. See
       -- 'ReportClusterProcess' for details.
       } deriving (Eq, Show, Typeable, Generic, Ord)
+
 instance Binary ReportClusterHost
 instance ToJSON ReportClusterHost
 instance FromJSON ReportClusterHost


### PR DESCRIPTION
`fromJust` is dangerous as it may cause runtime error:
```
λ> fromJust Nothing

<interactive>:5:1: error:
    Variable not in scope: fromJust :: Maybe a0 -> t
```

There is still one application of `fromJust` remaining in
mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Rules.hs
but at least there is a comment justifying its presence. (Also it is
2:17 AM and I'd rather go to bed.)