### PR TITLE
hctl: fix error when HALOND_STATION_OPTIONS is unset

### DIFF
--- a/mero-halon/scripts/hctl
+++ b/mero-halon/scripts/hctl
@@ -28,7 +28,7 @@ IP=${ADDR[0]}
 [ -n "$IP" ] || die "Cannot determine IP ($IP) from $HALOND_LISTEN"
 HALONCTL_LISTEN="$IP:0"
 
-[ -n "$HALOND_STATION_OPTIONS" ] &&
+[ "${HALOND_STATION_OPTIONS:=x}" != "x" ] &&
     export HALOND_STATION_OPTIONS
 
 exec halonctl -l "$HALONCTL_LISTEN" -a "$HALOND_LISTEN" "$@"


### PR DESCRIPTION
This is the addon to commit 8d71b60 where we started using
HALOND_STATION_OPTIONS parameter. hctl script uses `-u' option
so it complained like this:

/usr/bin/hctl: line 31: HALOND_STATION_OPTIONS: unbound variable

if the parameter was unset at /etc/sysconfig/halond.

Now we explicitly set this variable to default value at hctl
script if it is unset.