### PR TITLE
HALON-900: fix multi-nodes TS cluster bootstrap regression

### DIFF
--- a/replicated-log/src/Control/Distributed/Log/Internal.hs
+++ b/replicated-log/src/Control/Distributed/Log/Internal.hs
@@ -1938,7 +1938,11 @@ ambassador SerializableDict Config{logId, leaseTimeout} omchan replicas =
        (sp, rp) <- newChan
        timerPid <- spawnLocal $ link self >> timer sp
        forM_ replicas $ flip whereisRemoteAsync (batcherLabel logId)
-       usend timerPid leaseTimeout
+       -- Set it to 1 sec initially, so that the cluster bootstrap does not
+       -- depend on the leaseTimeout. Otherwise, the RC startup may be delayed
+       -- on a big leaseTimeouts and the satellites won't be able to start
+       -- during the bootstrap process. Especially, on multi-node-TS configs.
+       usend timerPid (1000000 :: Int)
        go AmbassadorState
          { asTimerPid = timerPid
          , asTimerRP  = rp


### PR DESCRIPTION
The same lease timeout which we increased in the commit 8d71b602 is also used by the ambassador to ping the
replicas and determine the leader. So the leader determination increased as well along with the RC startup
time. As a result, the satellites startup timed out during the bootstrap.

Now we just hard-code the initial ambassador timeout to 1 sec. It seems to be enough to quickly and reliably determine the leader during the bootstrap and also break the dependency of this determination process on the lease timeout configuration.