### PR TITLE
scripts/h0: fix cmd_install on vagrant singlenode

### DIFF
--- a/scripts/h0
+++ b/scripts/h0
@@ -238,10 +238,11 @@ cmd_genfacts() {
 
 cmd_install() {
     local quiet=--quiet
+    local eth1_is_present=$(ls /sys/class/net/ | grep eth1)
     [[ -v M0_VERBOSE ]] && quiet=''
     mpdsh sudo $M0_SRC_DIR/scripts/install-mero-service --link $quiet
     mpdsh sudo $H0_SRC_DIR/scripts/install-halon-services --link $quiet \
-          ${M0_CLUSTER:+'--iface eth1'}
+          ${eth1_is_present:+'--iface eth1'}
 }
 
 cmd_uninstall() {


### PR DESCRIPTION
On vagrant setup with bridge interface the cmd_install was
selecting the wrong interface and, as result, wrong IP address
for HALOND_LISTEN parameter on the singlenode configuration.

Now we just select eth1 interface (if present) which is the
default interface on vagrant setup. Otherwise, we allow
scripts/install-halon-services to select the interface.