### PR TITLE
HALON-895: fix cluster stuck after TS-node crash regression

### DIFF
--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Rules.hs
@@ -161,10 +161,8 @@ eventUpdatePrincipalRM = defineSimpleTask "castor::cluster::event::update-princi
 -- Nilpotent request.
 isRCNode :: NodeId -> Process Bool
 isRCNode nid = do
-    self <- getSelfPid
     whereisRemoteAsync nid labelRecoveryCoordinator
-    void . spawnLocal $ receiveTimeout 1000000 [] >> usend self ()
-    receiveWait [ match $ \(WhereIsReply _ mp) -> return (isJust mp) ]
+    isJust . join <$> receiveTimeout 1000000 [ match $ \(WhereIsReply _ mp) -> return mp ]
 
 requestClusterStatus :: Definitions RC ()
 requestClusterStatus = defineSimpleTask "castor::cluster::request::status"


### PR DESCRIPTION
The regression was introduced at commit 619bc5b0 in this code:

```
+isRCNode :: NodeId -> Process (Bool)
+isRCNode nid = do
+    self <- getSelfPid
+    whereisRemoteAsync nid labelRecoveryCoordinator
+    void . spawnLocal $ receiveTimeout (1000000) [] >> usend self ()
+    receiveWait
+      [ match (\(WhereIsReply _ mp) -> (if isNothing mp then return False else return True))]
+    where
+      labelRecoveryCoordinator = "mero-halon.RC"
```

There were two problems about the timeout here: 1) the timeout
event from the spawned thread was ignored and 2) the timeout
thread was not cancelled in normal (non-timeout) case.  So it
was always sending the `()' event to itself which could cause
all sorts of weird behaviours (including our one).

Now we don't spawn the timeout thread at all, but directly use
receiveTimeout instead of receiveWait.