### PR TITLE
`h0` script improvements

### DIFF
--- a/scripts/h0
+++ b/scripts/h0
@@ -183,7 +183,12 @@ cmd_fini() {
     cmd_check_access || true
     cmd_stop_halond || true
     cmd_stop_kernel || true
-    cmd_erase_data --keep-logs  # logs might be needed for debugging
+
+    for f in /var/log/halon.{decision,trace}.log; do
+        [[ -a $f ]] && sudo mv ${f}{,_preserved-for-debugging}
+    done
+    cmd_erase_data
+
     cmd_uninstall
 }
 
@@ -258,14 +263,7 @@ cmd_uninstall() {
 }
 
 cmd_erase_data() {
-    local arg="${1:-}"
-    [[ -z $arg ]] || [[ $arg == '--keep-logs' ]] ||
-        die "${FUNCNAME[0]}: Invalid usage"
-
-    # We cannot use `systemctl start halon-cleanup` here, because there is
-    # no convenient way to pass optional argument (`--keep-logs`)
-    # to a systemd service.
-    mpdsh sudo $H0_SRC_DIR/scripts/halon-cleanup $arg || true
+    mpdsh sudo systemctl start halon-cleanup || true
     mpdsh sudo systemctl start mero-cleanup || true
 
     # `/var/mero` directory cannot be deleted on Jenkins CI nodes,

--- a/scripts/halon-cleanup
+++ b/scripts/halon-cleanup
@@ -1,28 +1,26 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 # set -x
+export PS4='+ [${FUNCNAME[0]:+${FUNCNAME[0]}:}${LINENO}] '
 
 PROG=${0##*/}
-CLEAN_LOGS=1
 
 usage() {
     cat <<EOF
-Usage: $PROG [--keep-logs]
+Usage: $PROG [-h | --help]
 Stop Halon processes, delete persisted data, trace and log files.
 
-Options:
-    --keep-logs   Preserve /var/log/halon.decision.log and
-                  /var/log/halon.trace.log files.
+Option:
     -h, --help    Show this help and exit.
 EOF
 }
 
 die() { echo "$*" >&2; exit 1; }
+
 _kill() { killall -v -KILL "$@" 2>/dev/null || true; }
 
 case ${1:-} in
     -h|--help) usage; exit 0;;
-    --keep-logs) CLEAN_LOGS=0;;
     '') :;;
     *) die "Invalid argument. Type \`$PROG --help' for usage.";;
 esac
@@ -32,9 +30,7 @@ esac
 pids=$(pidof halond || true)
 
 _kill halonctl
-systemctl status halond &>/dev/null &&
-    systemctl stop halond ||
-        _kill halond
+systemctl status halond &>/dev/null && systemctl stop halond || _kill halond
 
 rm -rfv /var/lib/halon/halon-persistence/
 
@@ -42,4 +38,4 @@ for pid in $pids; do
     rm -fv {,/var/lib/halon/}m0trace.$pid
 done
 
-((CLEAN_LOGS == 0)) || rm -fv /var/log/halon.{decision,trace}.log
+rm -fv /var/log/halon.{decision,trace}.log


### PR DESCRIPTION
- Rename Halon log files (`/var/log/halon.{decision,trace}.log`) in `h0 fini` — add `_preserved-for-debugging` suffix.  `h0 init` won't overwrite those files.  The suffix makes it easy to differentiate old logs from current ones.
- Simplify `halon-cleanup` script: `--keep-logs` option is not needed any more.