### PR TITLE
COSTOR-1048 hctl cli arguments get logged to syslog.

### DIFF
--- a/mero-halon/mero-halon.cabal
+++ b/mero-halon/mero-halon.cabal
@@ -330,7 +330,8 @@ Executable halonctl
                       uuid,
                       network >= 2.4,
                       network-transport-tcp >= 0.3,
-                      rpclite
+                      rpclite,
+                      hslogger
 
 Executable haloninfo
   Hs-Source-Dirs:     src/haloninfo


### PR DESCRIPTION
Here is the sample of what appears to syslog:
```
May 30 06:31:40 qb08n3-m06-vm1 halonctl[22931]: [halonctl/DEBUG] halonctl has been invoked with CLI arguments: ["-l","10.230.165.145:0","-a","10.230.165.145:9070","halon","info","eq"]
```
- The idea behind this is that RAS component (once it is implemented) can ingest these logs and thus they become available at the cluster level.
- Link to the JIRA ticket: [COSTOR-1048](https://jts.seagate.com/browse/COSTOR-1048)