### PR TITLE
.gitlab-ci.yml: do better job at collecting decision log

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,7 +195,7 @@ ST singlenode:
                                 > $CI_PROJECT_DIR/${PREFIX}syslog.log
 
     # fetch halon.decision.log
-    - $M0VG scp cmu:/var/log/halon.decision.log
+    - $M0VG scp cmu:/var/log/halon.decision.log\*
                     $CI_PROJECT_DIR/${PREFIX}halon.decision.log
 
     # fetch m0trace
@@ -304,7 +304,7 @@ ST multinode:
                                 > $CI_PROJECT_DIR/${PREFIX}syslog.log
 
     # fetch halon.decision.log
-    - $M0VG scp cmu:/var/log/halon.decision.log
+    - $M0VG scp cmu:/var/log/halon.decision.log\*
                     $CI_PROJECT_DIR/${PREFIX}halon.decision.log
 
     # clean up (ensures that VMs are destroyed in case of a manual job restart,

--- a/st/multinode.t_satellite-restart
+++ b/st/multinode.t_satellite-restart
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 . $H0_SRC_DIR/st/common
 
-# TODO: find a better solution?
 SAT=${SAT:-ssu1}
 
 prepare_cluster_conf() {
@@ -57,9 +56,6 @@ END {
 }
 
 prepare_cluster_conf
-# FIXME: this check fails because ssh keys haven't been scanned yet at this
-#        point (the scan is performed later during `$H0 init`)
-#pdsh -S -w $($H0 hosts) true  # fail unless all hosts are accessible
 
 $H0 init
 cluster_bootstrap


### PR DESCRIPTION
`h0 fini` renames /var/log/halon.decision.log — adds `_preserved-for-debugging` suffix to the file name.  It is also
possible that tests will fail before `h0 fini` is called — in this case halon.decision.log will not be renamed.

Update .gitlab-ci.yml to have decision log collected, suffix or not.