### PR TITLE
EOS:167: 1+0 configuration: testing and debugging

### DIFF
--- a/st/t_1plus0.start-stop
+++ b/st/t_1plus0.start-stop
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+. $H0_SRC_DIR/st/common
+
+NODE=$(hostname)
+prepare_cluster_1plus0_conf() {
+    export M0_CLUSTER=$(mktemp)
+    trap "rm $M0_CLUSTER" 0
+
+    cat >$M0_CLUSTER <<EOF
+clovis-apps: [ $NODE ]
+confds:      [ $NODE ]
+ssus:
+  - host:  $NODE
+    disks:   /dev/loop1
+pools:
+  - name: pool1
+    disks: [ { host: '$NODE', filter: '/dev/loop1' } ]
+    data_units: 1
+    parity_units: 0
+EOF
+}
+
+LOG_FILE="$(mktemp --suffix _log_file)"
+SRC_OBJ="$(mktemp --suffix _src_file)"
+DEST_OBJ="$(mktemp --suffix _dest_file)"
+
+check_io_return() {
+    rm -rf $LOG_FILE $SRC_OBJ $DEST_OBJ
+    return $1
+}
+
+check_io() {
+        CLUSTER_PROFILE=$(hctl mero status | awk '/profile:/ {print $2}')
+        HA_EP=$(hctl mero status | awk '/halon \(RC\)/ {print $4}')
+        IFS=' ' read -ra CLOVIS_APPS_FIDS <<< $(hctl mero status | awk '/clovis-app/ {print $3}')
+        IFS=' ' read -ra CLOVIS_APPS_EPS <<< $(hctl mero status | awk '/clovis-app/ {print $4}')
+
+        OBJ_ID=1048580
+        BSIZE=4096
+        BCOUNT=1024
+
+        # XXX FIXME
+        # Immediate use of same clovis process endpoint for anther app failing.
+        # Using different endpoint for c0cp & c0cat
+        CLOVIS_PARAMS_CP="-l ${CLOVIS_APPS_EPS[0]} -H $HA_EP -p $CLUSTER_PROFILE \
+                       -P ${CLOVIS_APPS_FIDS[0]}"
+        CLOVIS_PARAMS_CAT="-l ${CLOVIS_APPS_EPS[1]} -H $HA_EP -p $CLUSTER_PROFILE \
+                       -P ${CLOVIS_APPS_FIDS[1]} -r"
+
+        dd if=/dev/urandom bs=$BSIZE count=$BCOUNT of=$SRC_OBJ 2> $LOG_FILE || return $?
+
+        sudo $M0_SRC_DIR/clovis/st/utils/c0cp $CLOVIS_PARAMS_CP -o $OBJ_ID \
+                                 -s $BSIZE -c $BCOUNT $SRC_OBJ || check_io_return $?
+
+        sudo $M0_SRC_DIR/clovis/st/utils/c0cat $CLOVIS_PARAMS_CAT -o $OBJ_ID -s $BSIZE \
+                                  -c $BCOUNT > $DEST_OBJ || check_io_return $?
+
+        diff  $SRC_OBJ $DEST_OBJ || return $?
+
+        check_io_return 0
+}
+
+sudo /data/mero/utils/m0setup -P 1 -N 1 -K 0 --no-cas
+prepare_cluster_1plus0_conf
+$H0 init
+cluster_bootstrap
+check_io
+hctl mero stop
+$H0 fini
+
+report_and_exit ${0##*/} $?


### PR DESCRIPTION
- Write ST to check 1+0 cluster configuration and bootstrap
- Verify IO using clovis apps (c0cp & c0cat)

Closes EOS-167