### PR TITLE
HALON-911: fix processes restart after node failure

### DIFF
--- a/halon/src/lib/HA/EventQueue.hs
+++ b/halon/src/lib/HA/EventQueue.hs
@@ -11,9 +11,10 @@
 -- have explicitly acknowledged to have handled them.
 --
 -- Upon receiving an event, the Recovery Coordinator must take recovery
--- measures and notify the Event Queue with a 'Trim' message that the recovery for a given event
--- or sequence of events is done. Upon receiving such notification, the Event
--- Queue component can delete the event from the replicated mailbox.
+-- measures and notify the Event Queue with a 'Trim' message that the recovery
+-- for a given event or sequence of events is done. Upon receiving such
+-- notification, the Event Queue component can delete the event from the
+-- replicated mailbox.
 --
 -- If a recovery procedure is interrupted due to a failure in the tracking
 -- station or in the RC, the Event Queue will send all unhandled events to

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Mero/Rules.hs
@@ -105,6 +105,7 @@ meroRules = do
     synchronize <- mkSyncAction _2 reply
     setPhase initial $ \(HAEvent eid afterSync) -> do
       put Local (eid, defaultConfSyncState)
+      Log.rcLog' Log.DEBUG $ show eid
       synchronize afterSync
     directly reply $ do
       uuid <- fst <$> get Local
@@ -118,6 +119,7 @@ meroRules = do
     synchronize <- mkSyncAction _2 reply
     setPhase initial $ \(uuid, afterSync) -> do
       put Local (uuid, defaultConfSyncState)
+      Log.rcLog' Log.DEBUG $ show uuid
       synchronize afterSync
     directly reply $ do
       uuid <- fst <$> get Local

--- a/mero-halon/src/lib/HA/Resources/Castor/Initial.hs
+++ b/mero-halon/src/lib/HA/Resources/Castor/Initial.hs
@@ -210,7 +210,7 @@ instance ToJSON M0Host
 data ProcessOwnership
   = Managed      -- ^ Process is started/monitored/stopped by Halon.
   | Independent  -- ^ Process is not controlled by Halon.
-  deriving (Eq, Data, Show, Generic)
+  deriving (Eq, Ord, Data, Show, Generic)
 instance Hashable ProcessOwnership
 instance FromJSON ProcessOwnership
 instance ToJSON ProcessOwnership
@@ -218,14 +218,15 @@ instance ToJSON ProcessOwnership
 -- XXX TODO:
 -- 1) s/PL/PT/
 -- 2) synchronize with Mero.Notification.HAState.ProcessType
+-- Ordered by bootstrap order.
 data ProcessType
-  = PLM0t1fs -- ^ Process lives as part of m0t1fs in kernel space.
-  | PLClovis String ProcessOwnership -- ^ Process lives as part of a
-                                     --   Clovis client, with given name.
+  = PLHalon  -- ^ Process lives inside Halon program space.
   | PLM0d Int  -- ^ Process runs in m0d at the given boot level.
                --   Currently 0 = confd, 1 = other.
-  | PLHalon  -- ^ Process lives inside Halon program space.
-  deriving (Eq, Data, Show, Typeable, Generic)
+  | PLM0t1fs -- ^ Process lives as part of m0t1fs in kernel space.
+  | PLClovis String ProcessOwnership -- ^ Process lives as part of a
+                                     --   Clovis client, with given name.
+  deriving (Eq, Ord, Data, Show, Typeable, Generic)
 instance Hashable ProcessType
 instance FromJSON ProcessType
 instance ToJSON ProcessType


### PR DESCRIPTION
It was possible that the node's processes would get stuck
in a failed state with 'node failure' status on cluster startup
sometimes. It happened because the node::process::start rule
instance was not finishing until all the cluster processes are
started up (including the client ones). As result, the attempt
to restart the processes on the failed and restored node was
failing because the node::process::start rule instance was
'already running'.

Now we finish the rule instance as soon as there are no more
processes left to start on the node or some previously started
processes on the node got failed already (due to the node failure,
for example).