### PR TITLE
Strip leading space from process type in `hctl mero status` output

### DIFF
--- a/mero-halon/src/halonctl/Handler/Mero/Status.hs
+++ b/mero-halon/src/halonctl/Handler/Mero/Status.hs
@@ -103,7 +103,7 @@ prettyReport showDevices nids ReportClusterState{..} = do
          forM_ ps $ \( M0.Process{r_fid=rfid, r_endpoint=endpoint}
                      , ReportClusterProcess ptype proc_st srvs ) -> do
            let (pst, proc_extSt) = M0.displayProcessState proc_st
-               tsTag | ptype /= " halon"         = "" :: String
+               tsTag | ptype /= "halon"          = "" :: String
                      | isRC                      = " (RC)"
                      | mnid `elem` map Just nids = " (TS)"
                      | otherwise                 = ""
@@ -142,7 +142,7 @@ prettyReport showDevices nids ReportClusterState{..} = do
      indentation = replicate 16 ' '
      pattern_ext = indentation ++ "Extended state: %s\n"
      node_pattern  = "  [%9s] %-24s  %s\n"
-     proc_pattern  = "  [%9s] %-24s    %s%s%s\n"
+     proc_pattern  = "  [%9s] %-24s    %s %s%s\n"
      serv_pattern  = "  [%9s] %-24s      %s%s\n"
      sdev_pattern  = "  [%9s] %-24s        %s %s\n"
      sdev_patterni = indentation ++ "%s\n"

--- a/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Rules.hs
+++ b/mero-halon/src/lib/HA/RecoveryCoordinator/Castor/Cluster/Rules.hs
@@ -221,14 +221,14 @@ requestClusterStatus = defineSimpleTask "castor::cluster::request::status"
         , csrPrincipalRM = getPrincipalRM' rg
         }
   where
-    getType (Just CI.PLHalon)           _ = " halon"
-    getType (Just CI.PLM0t1fs)          _ = " m0t1fs"
-    getType (Just (CI.PLClovis name _)) _ = ' ':name
+    getType (Just CI.PLHalon)           _ = "halon"
+    getType (Just CI.PLM0t1fs)          _ = "m0t1fs"
+    getType (Just (CI.PLClovis name _)) _ = name
     getType _ srvs
-      | any (\(M0.Service _ t _) -> t == CST_IOS) srvs   = " ioservice"
-      | any (\(M0.Service _ t _) -> t == CST_MDS) srvs   = " mdservice"
-      | any (\(M0.Service _ t _) -> t == CST_CONFD) srvs = " confd"
-      | otherwise                                        = " m0d"
+      | any (\(M0.Service _ t _) -> t == CST_IOS) srvs   = "ioservice"
+      | any (\(M0.Service _ t _) -> t == CST_MDS) srvs   = "mdservice"
+      | any (\(M0.Service _ t _) -> t == CST_CONFD) srvs = "confd"
+      | otherwise                                        = "m0d"
 
 jobClusterStart :: Job ClusterStartRequest ClusterStartResult
 jobClusterStart = Job "castor::cluster::start"


### PR DESCRIPTION
`requestClusterStatus` rule prepended a leading space character to
process type name (e.g., " halon", " m0d") in `hctl mero status` output.
This was ugly and broke @max-seagate.medved's `sage-user-application-assignment` script.

Kudos to @dmitriy.chumak for finding the bug!