### PR TITLE
Problem: CI tests fail

### DIFF
--- a/mero-halon/src/lib/Mero/Notification/HAState.hsc
+++ b/mero-halon/src/lib/Mero/Notification/HAState.hsc
@@ -536,6 +536,7 @@ notify (HALink hl) idx nvec ha_pfid ha_sfid epoch =
                      #{alignment struct m0_ha_msg_nvec} $ \pnvec -> do
     #{poke struct m0_ha_msg_nvec, hmnv_type} pnvec (0 :: Word64)
     #{poke struct m0_ha_msg_nvec, hmnv_id_of_get} pnvec idx
+    #{poke struct m0_ha_msg_nvec, hmnv_ignore_same_state} pnvec (0 :: Word64)
     #{poke struct m0_ha_msg_nvec, hmnv_nr} pnvec
         (fromIntegral $ length nvec :: Word64)
     pokeArray (#{ptr struct m0_ha_msg_nvec, hmnv_arr} pnvec) nvec


### PR DESCRIPTION
E.g., [“ST singlenode” job](http://gitlab.mero.colo.seagate.com/mero/halon/-/jobs/54793) fails with the following error message [in syslog](http://gitlab.mero.colo.seagate.com/mero/halon/-/jobs/54793/artifacts/file/st-single_syslog.log):
```
Sep 23 11:19:45.136605 halon50778-s-cmu mero-server[3083]: mero[03083]:  9780  FATAL  [lib/assert.c:48:m0_panic]  panic: (({ typeof (msg->hm_data.u.hed_nvec.hmnv_ignore_same_state) __x = (msg->hm_data.u.hed_nvec.hmnv_ignore_same_state); ((__x) == (0) || ((__x) == (1))); })) at m0_ha_msg_accept() (ha/note.c:198)  [git: 3c89e4b] /var/mero/m0d-0x7200000000000001:0x1b/m0trace.3083
Sep 23 11:19:45.136879 halon50778-s-cmu mero-server[3083]: Mero panic: (({ typeof (msg->hm_data.u.hed_nvec.hmnv_ignore_same_state) __x = (msg->hm_data.u.hed_nvec.hmnv_ignore_same_state); ((__x) == (0) || ((__x) == (1))); })) at m0_ha_msg_accept() ha/note.c:198 (errno: 0) (last failed: none) [git: 3c89e4b] pid: 3083  /var/mero/m0d-0x7200000000000001:0x1b/m0trace.3083
```

Apparently `halond` sends garbage in `m0_ha_msg_nvec::hmnv_ignore_same_state` field.

Solution: prior to sending `m0_ha_msg_nvec` to Mero, set its `hmnv_ignore_same_state` field
to `0` (false).

`hmnv_ignore_same_state` field has been added by Mero commit
mero/mero@08efd9f25fbc03f7e742957497515d68d3fc61f2
([c/18379](http://gerrit.mero.colo.seagate.com:8080/18379)).

